### PR TITLE
feat(recon): make --handles and verbose process evidence readable (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,87 @@ and JSON Schema details, see [docs/OUTPUT_SCHEMA.md](docs/OUTPUT_SCHEMA.md);
 for how to read the new fields as a triage analyst, see
 [docs/SOC_QUICKSTART.md](docs/SOC_QUICKSTART.md).
 
+## Changed: `--handles` and verbose `--process` output are now readable without the source
+
+Recon's console projection assumed the reader knew dumpex's internals
+([issue #98](https://github.com/bitbug0x55AA/dumpex/issues/98)). Four
+changes, all to what is **printed**. No JSON record shape, coverage
+meaning, limitation code, diagnostic, ordering rule or exit code changed,
+and the v2.13 schema is untouched — `--json` output is byte-identical
+across this release.
+
+**`--handles --verbose` now works.** It parsed before, but the CLI never
+forwarded it, so passing it had no effect at all. It is now wired through
+the dispatch, the command boundary, the renderer, the help text and
+`meta.execution.options`.
+
+**The default `--handles` console folds routine anonymous rows.** Rows
+whose object name the descriptor positively records as absent, and whose
+type is a low-context synchronization primitive (`Event`, `Mutant`,
+`Semaphore`, `Timer`, `IoCompletion`, `WaitCompletionPacket`, and
+similar), collapse into per-type counts:
+
+```text
+  11 anonymous handle(s) of routine low-context type(s) not shown: Event 9, Mutant 2
+  These rows are captured evidence and are complete in structured output -- use --verbose to show all.
+```
+
+Folding is a **projection, never a filter**: the folded rows are still
+counted in the headline and the `By type:` line, still in `summary`, and
+still in `--json`. Anonymous `Process`, `Thread`, `Token`, `Section` and
+`Job` handles are never folded — an anonymous handle to one of those is
+exactly the evidence a cross-process access question turns on — and
+neither is any row whose name could not be read. The type list is an
+allow list, so an unclassified (or dump-invented) type stays visible.
+
+**`(unnamed)` versus `(unreadable)` is now explained inline**, and common
+NT Object Manager names get a bounded note. `\KnownDlls` reads as what it
+is — an Object Manager directory whose name this descriptor recorded, not
+a filesystem path and not a list of DLLs — without claiming the objects
+inside it were captured. dumpex never expands such a directory from the
+analysis host.
+
+**`--process --verbose` explains its own addresses.** The import table
+used to print `<address> -> <address>` with no header and no legend, so
+which address was the IAT slot and which the resolved target was
+recoverable only from the source. It now has `DLL`, `Imported API`,
+`IAT Slot VA` and `Resolved Target VA` columns plus a one-line legend, and
+an IAT slot outside the recorded import directory bounds is flagged with
+`*` and a footnote — an observation about the dump's directory framing,
+not a verdict about the import.
+
+**`Evidence Matrix` became `Identity Verification`.** The old block
+printed the internal claim vocabulary (`peb`, `resolved`, `unregistered`,
+`ambiguous=false`) in fixed-width columns, and printed the source name
+`peb` in a column headed `Selected`, where a reader expects the selected
+value. The new block leads with the selected path, name, source and image
+base, then states one conclusion per check:
+
+```text
+  Identity Verification                            [--verbose only]
+    Selected path    C:\Samples\malware.exe
+    Source           PEB (ProcessParameters.ImagePathName)
+
+    [OK] PEB image base is registered in ModuleList
+         0x00007ff600010000 -> malware.exe
+    [OK] PEB and ModuleList process names agree
+    [OK] a valid PE header was found at the PEB image base
+```
+
+Each check reports `[OK]`, `[!!]` for a conflict, or `[--]` when it could
+not be evaluated; names are compared case-insensitively, so a case
+difference alone is not reported as a conflict. The raw per-source claims
+are still printed underneath. **An identity disagreement stays an
+observation** — it does not become a maliciousness verdict, a
+`peb_trusted` boolean, a command failure, or a coverage/exit-code change.
+
+**Every dump-derived string the verbose process renderer prints is now
+escaped** — paths, process and module names, the PE rejection reason, the
+import table's DLL and API names, and the Extended PEB's window title and
+DLL path — so a hostile name cannot forge dumpex's own output lines,
+clear the terminal, or visually reorder itself. `--json` keeps the exact
+decoded bytes, which is where evidence is read byte-for-byte.
+
 ## Fixed: `--sysinfo`'s `Dump Time` was a 1970 date on every dump
 
 `--sysinfo`'s `Dump Time` (and `dump_time_utc` in `--json`/`--csv`)

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -58,7 +58,7 @@ for the named commands, not additional command entry points.
 | Option | Applies to | Description |
 |---|---|---|
 | `--diff-scope modules\|threads\|memory\|all` | diff | Optional evidence-type filter for `--diff`; default `all` |
-| `--verbose` | diff, hunt | Include routine regions or additional detail |
+| `--verbose` | process, handles, sysinfo, diff, hunt | Include routine regions or additional detail. Console only — `--json` always carries every record (see [Verbose recon output](#verbose-recon-output)) |
 
 ### Hunt options
 
@@ -159,6 +159,72 @@ none reached a conclusive result — instead of its old unconditional `0`.
 
 See [Output and Evidence Schema](OUTPUT_SCHEMA.md) for formats and metadata.
 
+## Verbose recon output
+
+`--verbose` changes what `--process` and `--handles` **print**. It never
+changes what they collect: the records, coverage, limitations, summary
+counts and exit code are identical with and without it, so `--json` is
+always the complete, lossless evidence surface.
+
+### `--handles`
+
+The default console folds routine **anonymous** handle rows — rows whose
+object name the descriptor positively records as absent, and whose type
+is a low-context synchronization primitive (`Event`, `Mutant`,
+`Semaphore`, `Timer`, `IoCompletion`, and similar) — into per-type
+counts:
+
+```text
+  11 anonymous handle(s) of routine low-context type(s) not shown: Event 9, Mutant 2
+  These rows are captured evidence and are complete in structured output -- use --verbose to show all.
+```
+
+Those rows are still captured, still counted in the headline and the
+`By type:` line, and still in `--json`. `--verbose` prints all of them.
+
+Anonymous `Process`, `Thread`, `Token`, `Section` and `Job` handles are
+**never** folded, and neither is any row whose name could not be read.
+The two states are different facts and the console keeps them apart:
+
+- `(unnamed)` — the descriptor records no name. Nothing was lost.
+- `(unreadable)` — a name should have been there and the bounded read
+  or decode failed. Evidence was lost, and the run reports it as a
+  coverage limitation.
+
+Common NT Object Manager names are explained under `Object name notes`.
+For example, `\KnownDlls` is an Object Manager **directory**, not a
+filesystem path and not a list of DLLs; the handle descriptor records
+its name only, and the objects inside it are not captured by it. dumpex
+never expands such a directory from the machine running the analysis.
+
+### `--process`
+
+`--verbose` adds three blocks:
+
+- **The import table**, with headers and a legend for its address pair.
+  Each row reads `IAT Slot VA -> Resolved Target VA`: the slot is the
+  address where the import pointer is stored, and the target is the
+  address stored in that slot in the captured process memory. A slot
+  outside the recorded import directory bounds is flagged with `*` — an
+  observation about the dump's directory framing, not a verdict about
+  the import.
+- **`Identity Verification`**, which shows the selected path and name,
+  the source they came from, and one line per independent check with an
+  explicit state: `[OK]`, `[!!]` (conflict), or `[--]` (could not be
+  evaluated). The checks are ModuleList registration of the PEB image
+  base, PEB/ModuleList process-name agreement, PE-header validity at the
+  image base, and whether another module competes for the same name. The
+  raw per-source claims follow underneath. A conflict is an
+  **observation**: it never becomes a maliciousness verdict, a command
+  failure, or a change to the exit code.
+- **`Extended PEB`**, the fields the retired `--peb` command used to
+  print, also published as `peb_extended` in `--json`.
+
+Every string in these blocks that came out of the dump — paths, names,
+DLL and API names, window title — is escaped before it reaches the
+terminal, so a hostile name cannot forge dumpex's own output. `--json`
+keeps the exact decoded bytes.
+
 ## Examples
 
 ### Recon
@@ -166,7 +232,9 @@ See [Output and Evidence Schema](OUTPUT_SCHEMA.md) for formats and metadata.
 ```bash
 dumpex sample.dmp --sysinfo
 dumpex sample.dmp --process
+dumpex sample.dmp --process --verbose
 dumpex sample.dmp --handles
+dumpex sample.dmp --handles --verbose
 dumpex sample.dmp --profile
 dumpex sample.dmp --modules
 dumpex sample.dmp --threads

--- a/docs/SOC_QUICKSTART.md
+++ b/docs/SOC_QUICKSTART.md
@@ -24,6 +24,43 @@ directory (`--ref-dir DIR`) to run at all — see
 [Module Stomping](#module-stomping) below before concluding a "no
 stomping" result actually checked anything.
 
+## Reading recon evidence (`--process`, `--handles`)
+
+Recon commands report what the dump **recorded at capture time**. They
+never query a live process, and nothing they print should be read as a
+statement about the machine you are running on.
+
+Two console conventions are worth knowing before you read either
+command's output:
+
+- **`--verbose` changes the console only.** The records, coverage,
+  limitation codes and exit code are identical with and without it, so
+  `--json` is always the complete inventory. If a console line says
+  something is "not shown", it is still in the JSON.
+- **`(unnamed)` and `(unreadable)` are different facts.** `(unnamed)`
+  means the descriptor records no name — nothing was lost. `(unreadable)`
+  means a name should have been there and the bounded read failed —
+  evidence was lost, and it is reported as a coverage limitation.
+
+`--handles` folds routine anonymous rows (anonymous `Event`, `Mutant`,
+`Semaphore`, and similar low-context types) into per-type counts and
+tells you how many it folded; run it again with `--verbose` for the full
+inventory. Anonymous `Process`, `Thread`, `Token`, `Section` and `Job`
+handles are never folded — those are the ones a cross-process access
+question turns on. A name like `\KnownDlls` is a real NT Object Manager
+**directory**, not a filesystem path; the descriptor records the
+directory's name, and the objects inside it are not in the dump.
+
+`--process --verbose` prints the import table as
+`IAT Slot VA -> Resolved Target VA` — where the import pointer is
+stored, and what is stored there — followed by an `Identity
+Verification` block that states, per check, whether the PEB and
+ModuleListStream agreed (`[OK]`), conflicted (`[!!]`), or could not be
+compared (`[--]`). **A conflict is an observation, not a verdict.** A
+PEB/ModuleList disagreement is a lead worth pulling, and it is also
+something benign software produces; use `--hunt hollowing` and
+`--hunt injection` for the questions that carry a disposition.
+
 ## The four fields that matter
 
 `--json` wraps every hunter's result in dumpex's shared v2.12

--- a/docs/recon_process_sysinfo_handles_contract.md
+++ b/docs/recon_process_sysinfo_handles_contract.md
@@ -1,6 +1,6 @@
 # Recon `--process`/`--sysinfo`/`--handles` contract (issue #37)
 
-**Status: frozen decision record, revision 5 — self-contained.**
+**Status: frozen decision record, revision 6 — self-contained.**
 
 This document is the complete, normative contract for the v2.13 Recon
 redesign. Issues #38–#44 implement against **this file alone**: every
@@ -1547,7 +1547,7 @@ Frozen semantics:
   Import Address Table
     <one of the four mutually exclusive branches below, checked in
      order -- the first match wins, and exactly one always matches>
-    <table of entries, --verbose only>
+    <legend + headed table of entries, --verbose only -- see below>
 
   Identity
     <one line per identity_evidence.diagnostics entry, "[!] " prefix for
@@ -1618,21 +1618,126 @@ Rules:
   blank or a guessed value.
 - The default console stays concise and surfaces **actionable
   conflicts** — the `Identity` block prints diagnostics and nothing
-  else. The complete check/provenance matrix (every claim, its source,
-  its raw value, every check that ran and passed) is `--verbose` only:
+  else. The complete provenance and the per-check conclusions are
+  `--verbose` only.
+
+#### 3.8.1 The `--verbose` import table
+
+The pre-rev6 rendering was one line per entry, `<address> -> <address>`,
+with no header and no legend. The two addresses are **not
+interchangeable** — the first is the IAT slot (where the import pointer
+is stored), the second is the value currently in that slot — and which
+was which was recoverable only from the source. Frozen layout:
 
 ```
-  Evidence Matrix                                     [--verbose only]
-    Claim          Selected      PEB              ModuleList
-    path           peb           C:\…\malware.exe C:\Windows\Temp\malware.exe
-    image base     peb           0x00007ff6…      0x00007ff6…  (unregistered)
-    name           peb           malware.exe      malware.exe
-    Checks         main-image PE: valid | base match: unregistered |
-                   name candidate: ambiguous=false
+  Import Address Table
+    42 import(s) across 3 DLL(s)
+
+    Each row reads IAT Slot VA -> Resolved Target VA.
+    The slot is the address where the import pointer is stored; the target is the
+    address stored in that slot in the captured process memory.
+
+    DLL                       Imported API                  IAT Slot VA           Resolved Target VA
+    KERNEL32.dll              CreateFileW                   0x00007ff600021018    0x00007ffb12345678
+    KERNEL32.dll              ordinal #12                   0x00007ff600021020    0x00007ffb12345690
+    ADVAPI32.dll              (unavailable)                 0x00007ff600021028    0x00007ffb123456a0 *
+    * the IAT slot lies outside the recorded import directory bounds -- an observation
+      about this dump's directory framing, not a verdict about the import
 ```
 
-- `--verbose` also prints the IAT entry table and the `peb_extended`
-  block under an `Extended PEB` header.
+- The four column headers are frozen: `DLL`, `Imported API`,
+  `IAT Slot VA`, `Resolved Target VA`.
+- §3.5.3's three import states stay distinct and are read from
+  `import_by`, never inferred from a null `symbol`: a name, `ordinal
+  #N`, and `(unavailable)` (the loader had already overwritten
+  `OriginalFirstThunk`, so neither is recoverable).
+- `slot_in_bounds is false` is surfaced as a trailing `*` plus one
+  footnote, printed only when at least one row carries it. It remains an
+  **observation** (§3.5.5 files it as a diagnostic, never a limitation):
+  it must not become a coverage failure, an exit-code change, or a claim
+  about hooking — a target inside another module is ordinary for
+  forwarded exports and API-set resolution.
+- `dll` and `symbol` are strings read out of the dumped image and are
+  therefore attacker-controlled. Both go through `console_safe()` on
+  their way to the terminal, exactly like a handle's object name
+  (§5.6); the record and `--json` keep the exact decoded value.
+- Target-module/section/protection attribution is **out of scope here**
+  and stays out until it can be published through a copied future
+  schema — nothing in this block adds a field to v2.13.
+
+#### 3.8.2 `Identity Verification` (`--verbose` only)
+
+Replaces rev5's `Evidence Matrix`, which had three problems an
+investigator paid for on every read: it printed the internal claim
+vocabulary (`peb`, `resolved`, `unregistered`,
+`ambiguous=false`) and left the reader to translate it; it printed the
+**source name** (`peb`) in a column headed `Selected`, where a reader
+expects the selected **value**; and it led with fixed-width raw values
+instead of answering which checks agreed, conflicted, or could not be
+evaluated.
+
+```
+  Identity Verification                            [--verbose only]
+    Selected path    C:\Samples\malware.exe
+    Selected name    malware.exe
+    Source           PEB (ProcessParameters.ImagePathName)
+    Image base       0x00007ff600010000 (source: PEB)
+
+    [OK] PEB image base is registered in ModuleList
+         0x00007ff600010000 -> malware.exe
+    [OK] PEB and ModuleList process names agree
+    [OK] a valid PE header was found at the PEB image base
+    [OK] no competing module shares this process name
+
+    Raw claims       PEB                              ModuleList
+    path             C:\Samples\malware.exe           C:\Samples\malware.exe
+    name             malware.exe                      malware.exe
+    image base       0x00007ff600010000               0x00007ff600010000 (resolved)
+```
+
+- The selected **value** and its **source** are separate lines. A source
+  name is never printed where a value belongs.
+- Exactly four checks, in this frozen order, each on one line with an
+  explicit state — `[OK]`, `[!!]` (conflict), or `[--]` (could not be
+  evaluated):
+
+  1. **PEB image-base registration in ModuleList**, from
+     `module_claim.match_state` (§3.4.3): `resolved` → `[OK]` with the
+     base and module name; `unregistered` → `[!!]`, naming
+     `name_matched_candidate`'s competing base when there is one;
+     `unavailable` → `[--]`.
+  2. **Process-name agreement** between `peb_claim.name` and
+     `module_claim.name`, compared **case-insensitively** (Windows
+     module and file names are case-insensitive, so a case difference
+     alone is not a conflict worth sending an analyst to chase).
+     Either name `null` → `[--]`, never agreement and never a conflict.
+  3. **PE-header validity** at the PEB image base, from `main_image_pe`
+     (§3.4.4). `checked is false` is `[--]` — "the question could not be
+     asked" is a different answer from "asked, and the header is not a
+     PE", which is `[!!]` plus `parse_pe_header()`'s own `reason`.
+  4. **Corroboration / ambiguity**, from
+     `name_matched_candidate_ambiguous`: `true` → `[!!]` (only the first
+     of several same-named modules is reported, which the reader has to
+     know before treating checks 1–2 as decisive); otherwise `[OK]`, or
+     `[--]` when `match_state == "unavailable"` left nothing to
+     corroborate with.
+
+- The raw per-source claims stay available underneath, bounded to three
+  lines, so nothing the matrix showed is lost — those values simply stop
+  being the first thing a reader has to decode.
+- **Every state here is an observation.** An identity disagreement is
+  rendered as a disagreement and never becomes a maliciousness verdict,
+  a command failure, a `peb_trusted` boolean, or a change to
+  `coverage.status`, the limitation set, the diagnostics, or the exit
+  code. PEB/ModuleList disagreement has ordinary benign causes.
+- Every dump-derived string in this block — both paths, both names, and
+  the PE rejection reason — goes through `console_safe()`, the same
+  projection the default field block already applies to the path, name
+  and command line.
+
+- `--verbose` also prints the `peb_extended` block under an
+  `Extended PEB` header. Its `WindowTitle` and `DllPath` are PEB strings
+  and are escaped the same way.
 
 ### 3.9 Summary
 
@@ -2665,6 +2770,100 @@ reduction path is introduced.
   captured names ascending), never by count or record order, and
   `by_type` is then emitted in §1.5's order **on the final keys**.
 
+#### 5.6.1 Default console folding and `--verbose`
+
+`--handles` commonly emits many rows whose `Object` column is
+`(unnamed)`, which buries the handles an investigation turns on. The
+default console therefore **folds** the routine anonymous rows into
+per-type counts, and `--verbose` renders every record.
+
+```
+  Handle              Type            Access      Cnt  Ptr  Object
+  0x0000000000000234  File            0x0012019f    1   32  \Device\NamedPipe\mypipe
+  0x0000000000000300  Process         0x001fffff    1    1  (unnamed)
+  (unnamed) = the descriptor records no name; (unreadable) = a name was recorded but the bounded read failed
+
+  11 anonymous handle(s) of routine low-context type(s) not shown: Event 9, Mutant 2
+  These rows are captured evidence and are complete in structured output -- use --verbose to show all.
+```
+
+- **Verbosity is a projection, never a filter.** `collect_handles()`
+  takes no verbosity parameter at all, so the records, `summary.count`,
+  `summary.by_type`, `coverage`, the limitations and the exit code are
+  identical in both views. A folded row remains captured, normalized,
+  counted, and present in `--json`. The headline and the `By type:` line
+  always describe the **complete** inventory.
+- A row is folded only when **both** hold:
+  1. `object_name_status == "unnamed"` — the descriptor positively
+     records no object name. `"unreadable"` is evidence **loss** and is
+     never folded, in either name field: folding it would hide the one
+     row that says something was lost.
+  2. its captured `type_name` is on an explicitly approved list of
+     low-context types (synchronization/scheduling primitives whose
+     anonymous instances carry no name, path, or cross-process
+     reference: `Event`, `EtwRegistration`, `IoCompletion`,
+     `IoCompletionReserve`, `IRTimer`, `Mutant`, `Semaphore`, `Timer`,
+     `TpWorkerFactory`, `WaitCompletionPacket`).
+- `object_name_status == "unnamed"` alone is **not** a sufficient
+  suppression rule. An anonymous `Process`, `Thread`, `Token`,
+  `Section`, or `Job` handle is exactly the evidence a cross-process
+  access question turns on, and none of them are foldable.
+- The list is an **allow** list: an unclassified type — including one a
+  dump invents — stays visible. The failure mode of a new Windows object
+  type is a slightly longer table, never a hidden handle.
+- The fold line states the exact total and the per-type counts, ordered
+  by §1.5 (count descending, then type name ascending), and names
+  `--verbose` as the way to see them. Folding is deterministic, bounded,
+  and linear in the record count: it is decided per record with no
+  cross-row state.
+- The two null-name labels are explained inline whenever one of them is
+  on screen, so `(unnamed)` versus `(unreadable)` never has to be looked
+  up in the source.
+
+#### 5.6.2 Object-name notes
+
+Captured NT Object Manager names are explained, without pretending to
+enumerate evidence the dump does not carry:
+
+```
+  Object name notes
+    \KnownDlls (Directory)
+      NT Object Manager directory of pre-mapped system DLL sections. This descriptor
+      records the directory name only -- the section objects inside it are not
+      captured by it.
+    Directory
+      Directory handles name an NT Object Manager namespace directory. A directory's
+      child objects are not captured by its own descriptor.
+```
+
+- Notes are keyed by `(type_name, object_name)`, so a note is only
+  attached to a handle whose **type** agrees with it — a `File` handle a
+  dump chooses to name `\KnownDlls` gets no note at all rather than a
+  false one.
+- A note states only what **this descriptor** recorded. It must never
+  claim a directory's child objects were enumerated, and nothing here
+  may read the analysis host's own Object Manager namespace: that would
+  mix live host state into dump-time evidence and may describe an
+  entirely different machine (§5.7).
+- The block is **bounded by construction**: the per-name table is
+  frozen and de-duplicated, and every other captured `Directory` name
+  contributes to one shared generic line rather than a line of its own,
+  so a dump carrying 65,536 distinct directory names cannot turn the
+  notes into the output.
+- Notes are derived from the **collected** records, not from the printed
+  rows, so a note never disappears with a folded row.
+- The note label carries a dump-derived object name and is escaped with
+  `console_safe()` like every other name on this block.
+
+#### 5.6.3 `--verbose` wiring
+
+`--handles --verbose` is wired end-to-end: argparse, the CLI dispatch,
+`cmd_handles(mf, *, verbose=...)`, and the renderer's own keyword-only
+`verbose`. `--verbose`'s help text names `--handles`, and
+`meta.execution.options.verbose` records the flag as it does for every
+other command. Before rev6 the flag parsed but was never forwarded, so
+passing it had no effect at all.
+
 ### 5.7 Framing
 
 Every user-facing string describes **captured** evidence. `--handles`
@@ -3193,7 +3392,43 @@ excuses anything in §0–§8.
   `datetime.fromtimestamp()` raising is a sufficient timestamp check (it
   is platform-dependent). Added `MAX_IAT_READ_OPERATIONS`,
   `name_matched_candidate`, and per-field IAT nullability.
-- **rev5 (this revision)** — `--sysinfo`'s console layout and dump
+- **rev6 (this revision)** — the recon console projection, from an
+  investigator's report against the shipped v2.13 output
+  ([issue #98](https://github.com/bitbug0x55AA/dumpex/issues/98)). Four
+  presentation defects, no change to any record shape, coverage meaning,
+  limitation code, diagnostic, ordering rule, or exit code:
+
+  1. **`--handles --verbose` was silently ignored** — the CLI dispatch
+     never forwarded the flag. Now wired end-to-end (§5.6.3).
+  2. **A full anonymous handle inventory buried the useful rows.** §5.6.1
+     freezes a deterministic fold of approved low-context anonymous rows
+     into per-type counts, with the exact omitted count and a
+     `use --verbose to show all` hint. Folding is a projection: the
+     records, summary, `by_type`, coverage and exit code are identical
+     in both views, and `unnamed`/`unreadable` stay distinct — an
+     unreadable name is never folded.
+  3. **Real NT namespace names read as parser noise.** §5.6.2 adds
+     bounded, type-keyed notes (`\KnownDlls` and friends) that describe
+     only what the descriptor recorded and never enumerate a directory's
+     contents from the analysis host.
+  4. **The verbose process block spoke dumpex's internal vocabulary.**
+     §3.8.1 gives the import table headers and a legend for the
+     `IAT Slot VA -> Resolved Target VA` pair (and surfaces
+     `slot_in_bounds` as an observation with a footnote); §3.8.2 replaces
+     the `Evidence Matrix` with `Identity Verification`, which separates
+     the selected value from its source and states one `[OK]`/`[!!]`/
+     `[--]` conclusion per identity check, keeping the raw claims
+     available underneath. Every dump-derived string the verbose renderer
+     prints — both paths, both names, the PE rejection reason, the import
+     table's DLL/API names, and the Extended PEB's window title and DLL
+     path — now goes through `console_safe()`.
+
+  Identity disagreement remains an observation throughout: no `peb_trusted`
+  boolean, no verdict, no command failure. This revision is
+  behaviour-compatible with everything already published — v2.13's JSON
+  is byte-identical across it, so no schema version moves and the frozen
+  historical schemas and fixtures are untouched.
+- **rev5** — `--sysinfo`'s console layout and dump
   identity, from an analyst's report against the shipped rev4 output.
   Three defects, all in §4:
 

--- a/dumpex/cli.py
+++ b/dumpex/cli.py
@@ -164,10 +164,13 @@ def main():
 
     display_group = parser.add_argument_group("display options")
     display_group.add_argument('--verbose', action='store_true',
-                               help='Show additional detail for --process, --sysinfo, --diff or '
-                                    '--hunt (--process: adds the retired --peb-only fields under '
-                                    'peb_extended; --sysinfo: prints environment variable values, '
-                                    'which may contain secrets)')
+                               help='Show additional detail for --process, --sysinfo, --handles, '
+                                    '--diff or --hunt (--process: adds the retired --peb-only '
+                                    'fields under peb_extended, plus the import table and the '
+                                    'identity checks; --handles: shows every captured handle row '
+                                    'instead of folding routine anonymous ones; --sysinfo: prints '
+                                    'environment variable values, which may contain secrets). '
+                                    'Console detail only -- --json always carries every record.')
 
     hunt_group = parser.add_argument_group("hunt options")
     hunt_group.add_argument('--yara-dir', metavar='DIR', default=None,
@@ -402,7 +405,10 @@ def _run(args, mf, out, cmd_label, *, mf_reference=None) -> "int | None":
     elif args.process:
         exit_code = _apply_command_result(cmd_process(mf, verbose=args.verbose))
     elif args.handles:
-        exit_code = _apply_command_result(cmd_handles(mf))
+        # #98: --verbose reaches the RENDERER only (see cmd_handles) --
+        # the collected records and the JSON they become are identical
+        # with and without it.
+        exit_code = _apply_command_result(cmd_handles(mf, verbose=args.verbose))
     elif args.profile:
         exit_code = _apply_command_result(cmd_profile(mf))
     elif args.sysinfo:

--- a/dumpex/commands/handles.py
+++ b/dumpex/commands/handles.py
@@ -21,11 +21,17 @@ fewer handles with a `complete` verdict.
 and CoverageReport -- it never touches `mf` (its signature has no `mf`
 parameter), matching every other recon renderer's rule.
 
-Per #42's non-goals, `--handles` is not wired into argparse and
-CURRENT_SCHEMA is not touched here -- #43 owns that atomic cutover.
-`cmd_handles()` exists so a future CLI wiring (and this module's own
-tests) has one call that collects and renders in the usual command
-shape.
+`cmd_handles()` is the one call that collects and renders in the usual
+command shape; #43 wired it into argparse, and #98 wired `--verbose`
+through to it.
+
+Console verbosity is a PROJECTION and nothing else (#98): the
+CommandResult `collect_handles()` returns is byte-identical whatever
+`verbose` is, so `--json` always carries the complete normalized
+inventory. The default console folds the low-context anonymous rows
+listed in `_FOLDABLE_ANONYMOUS_TYPES` into per-type counts and says
+exactly how many it folded; `--verbose` renders every record. Nothing is
+ever removed from the records, the summary, or `by_type`.
 """
 from minidump.constants import MINIDUMP_STREAM_TYPE
 from minidump.minidumpfile import MinidumpFile
@@ -442,7 +448,154 @@ _TYPE_COLUMN_WIDTH = 14
 _ACCESS_COLUMN_WIDTH = 10
 
 
-def render_handles_console(records, coverage) -> None:
+# ── #98: console folding, kept strictly a projection ────────────────────
+# The default console folds ONLY the anonymous rows of these types into
+# per-type counts. Two independent conditions have to hold before a row
+# is folded, and neither is sufficient alone:
+#
+#   1. `object_name_status == "unnamed"` -- the descriptor positively
+#      records no object name (§5.2.1). An "unreadable" name is EVIDENCE
+#      LOSS and is never folded: folding it would hide the one row an
+#      analyst needs to see to know something was lost.
+#   2. the captured type is on this explicitly approved list.
+#
+# Condition 2 exists because condition 1 alone is far too aggressive: an
+# anonymous Process, Thread, Token, Section, or Job handle is exactly the
+# kind of evidence a cross-process-access question turns on, and none of
+# those appear below. The list is an ALLOW list, so a type nobody has
+# considered (including a type name a dump invents) stays visible by
+# default -- the failure mode of a new Windows object type is a slightly
+# longer table, never a hidden handle.
+#
+# Every type here is a synchronization/scheduling primitive whose
+# anonymous instances carry no name, no path, and no cross-process
+# reference: with no object name there is nothing left in the descriptor
+# to investigate beyond the per-type count the fold line prints.
+_FOLDABLE_ANONYMOUS_TYPES = frozenset({
+    "Event",
+    "EtwRegistration",
+    "IoCompletion",
+    "IoCompletionReserve",
+    "IRTimer",
+    "Mutant",
+    "Semaphore",
+    "Timer",
+    "TpWorkerFactory",
+    "WaitCompletionPacket",
+})
+
+# Frozen, per-name explanations for NT Object Manager names an analyst
+# meets routinely and cannot tell from a filesystem path. Keyed by
+# (type_name, object_name) so a note is only attached to a handle whose
+# TYPE agrees with it -- a File handle a dump chooses to name
+# `\KnownDlls` gets no note at all rather than a false one.
+#
+# Every string is OBSERVATIONAL and describes only what THIS descriptor
+# recorded. None may claim the directory's contents were enumerated:
+# nothing in this command reads the Object Manager namespace, and #98's
+# resource rules forbid expanding a Directory handle from the analysis
+# host (which would describe the wrong machine anyway).
+_NT_NAMESPACE_NOTES = {
+    ("Directory", r"\KnownDlls"): (
+        "NT Object Manager directory of pre-mapped system DLL sections. This",
+        "descriptor records the directory name only -- the section objects inside",
+        "it are not captured by it.",
+    ),
+    ("Directory", r"\KnownDlls32"): (
+        "NT Object Manager directory of pre-mapped 32-bit system DLL sections on a",
+        "64-bit system. This descriptor records the directory name only.",
+    ),
+    ("Directory", r"\BaseNamedObjects"): (
+        "NT Object Manager directory holding session-wide named objects. This",
+        "descriptor records the directory name only -- the named objects inside it",
+        "are not captured by it.",
+    ),
+    ("Directory", r"\RPC Control"): (
+        "NT Object Manager directory holding RPC/ALPC endpoint names. This",
+        "descriptor records the directory name only.",
+    ),
+    ("Directory", r"\GLOBAL??"): (
+        "NT Object Manager directory of DOS device symbolic links (C:,",
+        "PhysicalDrive0, ...). This descriptor records the directory name only.",
+    ),
+}
+
+# The one note emitted for any OTHER captured Directory name, so an
+# unlisted directory is still explained without this table having to
+# enumerate a namespace. Bounded by construction: at most one such entry,
+# however many Directory handles a dump carries.
+_GENERIC_DIRECTORY_NOTE = (
+    "Directory handles name an NT Object Manager namespace directory. A",
+    "directory's child objects are not captured by its own descriptor.",
+)
+
+_FOLD_HINT = ("These rows are captured evidence and are complete in structured "
+              "output -- use --verbose to show all.")
+
+_NAME_STATUS_LEGEND = (
+    "(unnamed) = the descriptor records no name; "
+    "(unreadable) = a name was recorded but the bounded read failed")
+
+
+def _is_foldable(record: HandleRecord) -> bool:
+    """One record in, one bool out -- no cross-row state, so folding is
+    deterministic and linear in the record count however the table is
+    ordered. Both name statuses are read as themselves (never as bare
+    truthiness of the name): "unnamed" and "unreadable" are different
+    facts (§5.2.1) and only the first is ever foldable."""
+    return (record.object_name_status == "unnamed"
+            and record.type_name_status == "ok"
+            and record.type_name in _FOLDABLE_ANONYMOUS_TYPES)
+
+
+def _partition_for_console(records, verbose: bool) -> "tuple[list, dict]":
+    """-> (rows_to_print, {type_name: folded_count}).
+
+    `verbose` folds nothing at all. The folded counts are ordered by
+    §1.5's frozen rule (count descending, then type name ascending) so
+    two runs over the same dump print the same line."""
+    if verbose:
+        return list(records), {}
+    shown = []
+    folded = {}
+    for record in records:
+        if _is_foldable(record):
+            folded[record.type_name] = folded.get(record.type_name, 0) + 1
+        else:
+            shown.append(record)
+    return shown, dict(sorted(folded.items(), key=lambda item: (-item[1], item[0])))
+
+
+def _namespace_notes(records) -> list:
+    """The bounded semantic notes for §5.6's Object column, derived from
+    ALL collected records (never only the printed ones -- a folded row is
+    still captured evidence, and its note would otherwise disappear with
+    it).
+
+    Bounded by `len(_NT_NAMESPACE_NOTES) + 1` regardless of how many
+    handles a dump carries: named entries are de-duplicated, and every
+    other captured Directory name contributes to ONE generic line rather
+    than a line of its own. A dump carrying 65,536 distinct Directory
+    names therefore cannot turn this block into the output."""
+    seen = {}
+    other_directory = False
+    for record in records:
+        if record.type_name_status != "ok" or record.object_name_status != "ok":
+            continue
+        key = (record.type_name, record.object_name)
+        note = _NT_NAMESPACE_NOTES.get(key)
+        if note is not None:
+            seen[key] = note
+        elif record.type_name == "Directory":
+            other_directory = True
+    lines = [(f"{name} ({type_name})", note)
+             for (type_name, name), note in sorted(seen.items(), key=lambda i: (i[0][1], i[0][0]))]
+    if other_directory:
+        lines.append(("Directory", _GENERIC_DIRECTORY_NOTE))
+    return lines
+
+
+def render_handles_console(records, coverage, *, verbose: bool = False) -> None:
     """Projects ONLY the collected records and CoverageReport -- it never
     re-reads `mf.handles`, so console and JSON can never describe two
     different reads of the same dump.
@@ -452,7 +605,15 @@ def render_handles_console(records, coverage) -> None:
     console_safe() on its way to the terminal (§5.7 is about not implying
     live state; this is about a name not being able to forge dumpex's own
     output at all). The records and the summary keep the exact decoded
-    values, so `--json` is unaffected."""
+    values, so `--json` is unaffected.
+
+    `verbose` (#98) selects between two PROJECTIONS of the same records
+    and changes nothing else: the headline, `By type:` (which always
+    counts the complete inventory, folded rows included), the
+    limitations, and the coverage reasons are identical either way. The
+    default view folds the approved low-context anonymous rows into
+    per-type counts and states, in the output itself, how many rows were
+    folded and how to see them; `--verbose` prints every record."""
     print(f"\n{BOLD('═══ HANDLES ═══')}")
     print(f"  {_headline(records, coverage)}")
 
@@ -474,12 +635,15 @@ def render_handles_console(records, coverage) -> None:
                 f"-- see coverage.limitations")
         print(f"  {YELLOW(text)}")
 
-    if records:
+    shown, folded = _partition_for_console(records, verbose)
+    folded_total = sum(folded.values())
+
+    if shown:
         header = (f"{'Handle':<18}  {'Type':<{_TYPE_COLUMN_WIDTH}}  "
                   f"{'Access':<{_ACCESS_COLUMN_WIDTH}}  {'Cnt':>3}  {'Ptr':>3}  Object")
         print()
         print(f"  {DIM(header)}")
-        for record in records:
+        for record in shown:
             type_display = console_safe(
                 handle_name_display(record.type_name, record.type_name_status))
             object_display = console_safe(
@@ -488,6 +652,35 @@ def render_handles_console(records, coverage) -> None:
                   f"{_access_display(record):<{_ACCESS_COLUMN_WIDTH}}  "
                   f"{_count_display(record.handle_count):>3}  "
                   f"{_count_display(record.pointer_count):>3}  {object_display}")
+
+    # The two null-name labels are dumpex's own vocabulary and mean two
+    # different things (§5.2.1); printed only when one of them is
+    # actually on screen, so the legend never describes rows that are not
+    # there. Read off the PRINTED rows, not the record list.
+    if any(record.type_name_status != "ok" or record.object_name_status != "ok"
+            for record in shown):
+        print(f"  {DIM(_NAME_STATUS_LEGEND)}")
+
+    # #98: exactly how many rows the default view folded, in per-type
+    # counts, with the way to see them. Every folded row is still a
+    # collected record -- it is in `by_type` above, in `summary.count`,
+    # and in --json -- so this line says "not shown", never "not
+    # captured".
+    if folded_total:
+        listed = ", ".join(f"{console_safe(name)} {count}" for name, count in folded.items())
+        print()
+        print(f"  {folded_total} anonymous handle(s) of routine low-context type(s) "
+              f"not shown: {listed}")
+        print(f"  {DIM(_FOLD_HINT)}")
+
+    notes = _namespace_notes(records)
+    if notes:
+        print()
+        print(f"  {BOLD('Object name notes')}")
+        for label, note_lines in notes:
+            print(f"    {console_safe(label)}")
+            for line in note_lines:
+                print(f"      {line}")
 
     for reason in coverage.reasons:
         # Frozen dumpex text in every case except SOURCE_FAILED's detail,
@@ -498,7 +691,11 @@ def render_handles_console(records, coverage) -> None:
     print()
 
 
-def cmd_handles(mf: MinidumpFile) -> CommandResult:
+def cmd_handles(mf: MinidumpFile, *, verbose: bool = False) -> CommandResult:
+    """`verbose` reaches the RENDERER only. `collect_handles()` takes no
+    verbosity at all, which is what makes "console filtering never
+    removes a record from --json" a structural property rather than a
+    rule someone has to remember (#98)."""
     result = collect_handles(mf)
-    render_handles_console(result.records, result.coverage)
+    render_handles_console(result.records, result.coverage, verbose=verbose)
     return result

--- a/dumpex/commands/process.py
+++ b/dumpex/commands/process.py
@@ -14,11 +14,16 @@ signature has no `mf` parameter), matching the contract's "rendering
 must use only the collected ProcessRecord, coverage, and diagnostics"
 rule (§3.8).
 
-Per #40's non-goals, `--process` is not wired into argparse and
-CURRENT_SCHEMA is not touched here -- #43 owns that atomic cutover.
-`cmd_process()` exists so a future CLI wiring (and this module's own
-tests) has one call that collects and renders in the usual command
-shape.
+`cmd_process()` is the one call that collects and renders in the usual
+command shape; #43 wired it into argparse.
+
+Issue #98 changed the VERBOSE CONSOLE PROJECTION only: the import table
+gained column headers and a legend for the slot/target address pair, and
+the old `Evidence Matrix` became an `Identity Verification` block that
+states one investigator-facing conclusion per identity check instead of
+printing the internal claim vocabulary. No record shape, coverage
+meaning, limitation code, diagnostic, or exit code moved with it -- the
+v2.13 JSON is byte-identical across that change.
 """
 from minidump.constants import MINIDUMP_STREAM_TYPE
 from minidump.minidumpfile import MinidumpFile
@@ -511,52 +516,231 @@ def render_process_console(record: ProcessRecord, coverage, *, verbose: bool = F
     _print_diagnostics(d.to_dict() for d in record.iat.diagnostics)
 
     if verbose and record.iat.entries:
-        print()
-        for e in record.iat.entries:
-            if e.import_by == "name":
-                symbol_text = e.symbol or "(unknown)"
-            elif e.import_by == "ordinal":
-                symbol_text = f"ordinal #{e.ordinal}"
-            else:
-                symbol_text = "(unavailable)"
-            print(f"      {(e.dll or '(unknown)'):<24} {symbol_text:<28} "
-                  f"{(e.iat_slot_va or '(unknown)'):<20} -> {e.resolved_target_va or '(unknown)'}")
+        _render_iat_entries(record.iat.entries)
 
     print(f"\n  {BOLD('Identity')}")
     _print_diagnostics(record.identity_evidence.get("diagnostics") or [])
 
     if verbose:
-        _render_evidence_matrix(record)
+        _render_identity_verification(record)
         if record.peb_extended is not None:
             _render_extended_peb(record.peb_extended)
 
 
-def _render_evidence_matrix(record: ProcessRecord) -> None:
+# ── #98: verbose IAT table ──────────────────────────────────────────────
+# The pre-#98 rendering was `<address_1> -> <address_2>` with no headers
+# and no legend, which is ambiguous in exactly the way that matters: the
+# two addresses are not interchangeable, and reading them the wrong way
+# round inverts the question ("where is the pointer stored" vs "where
+# does it point"). The headers and the one legend line below are the
+# whole fix; no new evidence is read, and the v2.13 record shape is
+# untouched.
+_IAT_DLL_COLUMN_WIDTH = 24
+_IAT_SYMBOL_COLUMN_WIDTH = 28
+_IAT_ADDRESS_COLUMN_WIDTH = 20
+
+# Pre-wrapped rather than wrapped at print time: dumpex's own text, at a
+# fixed width, so the block is byte-identical on every terminal.
+_IAT_LEGEND_LINES = (
+    "Each row reads IAT Slot VA -> Resolved Target VA.",
+    "The slot is the address where the import pointer is stored; the target is the",
+    "address stored in that slot in the captured process memory.",
+)
+
+# `slot_in_bounds is False` is an OBSERVATION (§3.5.5 files it as a
+# diagnostic, never a limitation), so it is surfaced as a per-row marker
+# with a footnote rather than as a verdict, a coverage failure, or a
+# claim about hooking -- a target inside another module is ordinary for
+# forwarded exports and API-set resolution.
+_IAT_OUT_OF_BOUNDS_MARKER = " *"
+_IAT_OUT_OF_BOUNDS_NOTE = ("* the IAT slot lies outside the recorded import directory "
+                           "bounds -- an observation about this dump's directory "
+                           "framing, not a verdict about the import")
+
+
+def _import_symbol_text(entry: ImportEntryRecord) -> str:
+    """§3.5.3's three import states, each kept distinct: a named import,
+    an ordinal-only import, and one whose name/ordinal could not be
+    recovered at all (OriginalFirstThunk already overwritten). Read from
+    `import_by`, never inferred from whether `symbol` happens to be
+    null."""
+    if entry.import_by == "name":
+        return entry.symbol or "(unknown)"
+    if entry.import_by == "ordinal":
+        return f"ordinal #{entry.ordinal}"
+    return "(unavailable)"
+
+
+def _render_iat_entries(entries) -> None:
+    """`dll`/`symbol` are strings read out of the dumped image, so they
+    are attacker-controlled exactly like a handle's object name -- both
+    go through console_safe() here, while the record and --json keep the
+    exact decoded value."""
+    print()
+    for line in _IAT_LEGEND_LINES:
+        print(f"    {line}")
+    print()
+    header = (f"{'DLL':<{_IAT_DLL_COLUMN_WIDTH}}  {'Imported API':<{_IAT_SYMBOL_COLUMN_WIDTH}}  "
+              f"{'IAT Slot VA':<{_IAT_ADDRESS_COLUMN_WIDTH}}  Resolved Target VA")
+    print(f"    {header}")
+    any_out_of_bounds = False
+    for e in entries:
+        dll_text = console_safe(e.dll) or "(unknown)"
+        symbol_text = console_safe(_import_symbol_text(e))
+        marker = ""
+        if e.slot_in_bounds is False:
+            marker = _IAT_OUT_OF_BOUNDS_MARKER
+            any_out_of_bounds = True
+        print(f"    {dll_text:<{_IAT_DLL_COLUMN_WIDTH}}  {symbol_text:<{_IAT_SYMBOL_COLUMN_WIDTH}}  "
+              f"{(e.iat_slot_va or '(unknown)'):<{_IAT_ADDRESS_COLUMN_WIDTH}}  "
+              f"{e.resolved_target_va or '(unknown)'}{marker}")
+    if any_out_of_bounds:
+        print(f"    {_IAT_OUT_OF_BOUNDS_NOTE}")
+
+
+# ── #98: Identity Verification (was "Evidence Matrix") ──────────────────
+# The matrix printed the internal claim vocabulary (`peb`, `resolved`,
+# `unregistered`, `ambiguous=False`) in fixed-width columns and left the
+# reader to translate it. Worse, its `Selected` column printed the SOURCE
+# NAME ("peb") where a reader expects the selected VALUE. This block
+# leads with the selected value and its provenance, then states one
+# investigator-facing conclusion per check.
+#
+# Every check is an OBSERVATION. A conflict is rendered as a conflict and
+# never as a maliciousness verdict, never as a command failure, and never
+# as a `peb_trusted` boolean -- disagreement between the PEB and
+# ModuleListStream has ordinary benign causes, and the coverage status,
+# the limitation codes and the exit code are all unchanged by anything
+# printed here.
+_CHECK_OK = "[OK]"
+_CHECK_CONFLICT = "[!!]"
+_CHECK_UNAVAILABLE = "[--]"
+
+# Display names for §3.4's `selected_path_source`, so this block never
+# prints an internal source key at an analyst.
+_PATH_SOURCE_DISPLAY = {
+    "peb": "PEB (ProcessParameters.ImagePathName)",
+    "module": "ModuleListStream (module registered at the PEB image base)",
+}
+
+
+def _print_check(state: str, text: str, detail: "str | None" = None) -> None:
+    print(f"    {state} {text}")
+    if detail:
+        print(f"         {detail}")
+
+
+def _module_registration_check(mod_claim: dict) -> tuple:
+    """§3.4.3's three `match_state` values, each turned into the question
+    an analyst is actually asking: is the image the PEB points at
+    registered in the loader's own module list?"""
+    state = mod_claim["match_state"]
+    if state == "resolved":
+        return (_CHECK_OK, "PEB image base is registered in ModuleList",
+                f"{mod_claim['base_address']} -> "
+                f"{console_safe(mod_claim['name']) or '(unnamed)'}")
+    if state == "unregistered":
+        candidate = mod_claim["name_matched_candidate"]
+        detail = None
+        if candidate is not None:
+            detail = (f"a module named {console_safe(candidate['name']) or '(unnamed)'} is "
+                      f"registered at {candidate['base_address']} instead")
+        return (_CHECK_CONFLICT, "no module is registered at the PEB image base", detail)
+    return (_CHECK_UNAVAILABLE,
+            "PEB image base could not be compared with ModuleList",
+            "ModuleListStream is absent or failed, or no image base normalized")
+
+
+def _name_agreement_check(peb_claim: dict, mod_claim: dict) -> tuple:
+    """Compared case-insensitively: Windows filesystem and module names
+    are case-insensitive, so a case difference alone is not a conflict an
+    analyst should be sent to chase."""
+    peb_name, mod_name = peb_claim["name"], mod_claim["name"]
+    if peb_name is None or mod_name is None:
+        return (_CHECK_UNAVAILABLE,
+                "PEB and ModuleList process names could not be compared",
+                "one of the two names was not recovered")
+    if peb_name.casefold() == mod_name.casefold():
+        return (_CHECK_OK, "PEB and ModuleList process names agree", None)
+    return (_CHECK_CONFLICT, "PEB and ModuleList process names differ",
+            f"PEB: {console_safe(peb_name)} | ModuleList: {console_safe(mod_name)}")
+
+
+def _pe_header_check(main_pe: dict) -> tuple:
+    """`checked`/`valid`/`reason` exactly as §3.4.4 defines them --
+    `checked is False` is "the question could not be asked", which is a
+    different answer from "asked, and the header is not a PE"."""
+    if not main_pe["checked"]:
+        return (_CHECK_UNAVAILABLE,
+                "the PEB image base was not checked for a PE header",
+                "no image base normalized, or nothing was captured there")
+    if main_pe["valid"]:
+        return (_CHECK_OK, "a valid PE header was found at the PEB image base", None)
+    return (_CHECK_CONFLICT, "no valid PE header at the PEB image base",
+            console_safe(main_pe["reason"]) or "(no reason recorded)")
+
+
+def _corroboration_check(mod_claim: dict) -> tuple:
+    """The ambiguity leg of §3.4.3: more than one module sharing the
+    selected name means only the first was reported, which an analyst has
+    to know before treating either of the checks above as decisive."""
+    if mod_claim["name_matched_candidate_ambiguous"]:
+        return (_CHECK_CONFLICT,
+                "more than one module shares this process name; only the first is reported",
+                "compare --modules for every module carrying this name")
+    if mod_claim["match_state"] == "unavailable":
+        return (_CHECK_UNAVAILABLE,
+                "no ModuleList corroboration was available for this identity", None)
+    return (_CHECK_OK, "no competing module shares this process name", None)
+
+
+def _render_identity_verification(record: ProcessRecord) -> None:
+    """Leads with the selected values and where they came from, then one
+    line per independent check. The raw per-source claims stay available
+    underneath (bounded, three lines), so nothing the old matrix showed
+    is lost -- those values simply stop being the first thing a reader
+    has to decode.
+
+    Every dump-derived string here -- both paths, both names, and the PE
+    rejection reason -- goes through console_safe(), the same projection
+    the default block above already used for the same values."""
     ev = record.identity_evidence
     peb_claim = ev["peb_claim"]
     mod_claim = ev["module_claim"]
     main_pe = ev["main_image_pe"]
-    print(f"\n  {BOLD('Evidence Matrix')}                                     [--verbose only]")
-    print(f"    {'Claim':<12} {'Selected':<10} {'PEB':<20} {'ModuleList'}")
-    print(f"    {'path':<12} {(ev['selected_path_source'] or '(none)'):<10} "
-          f"{(peb_claim['image_path'] or '(none)'):<20} {(mod_claim['path'] or '(none)')}")
-    print(f"    {'image base':<12} {'peb':<10} "
-          f"{(peb_claim['image_base_address'] or '(none)'):<20} "
-          f"{(mod_claim['base_address'] or '(none)')} ({mod_claim['match_state']})")
-    print(f"    {'name':<12} {(ev['selected_path_source'] or '(none)'):<10} "
-          f"{(peb_claim['name'] or '(none)'):<20} {(mod_claim['name'] or '(none)')}")
-    checks = (f"main-image PE: {'valid' if main_pe['valid'] else main_pe['reason'] or '(not checked)'} | "
-              f"base match: {mod_claim['match_state']} | "
-              f"name candidate: ambiguous={mod_claim['name_matched_candidate_ambiguous']}")
-    print(f"    {'Checks':<12} {checks}")
+    source = ev["selected_path_source"]
+
+    print(f"\n  {BOLD('Identity Verification')}                            [--verbose only]")
+    print(f"    {'Selected path':<16} {console_safe(record.process_path) or '(unknown)'}")
+    print(f"    {'Selected name':<16} {console_safe(record.process_name) or '(unknown)'}")
+    print(f"    {'Source':<16} {_PATH_SOURCE_DISPLAY.get(source, '(no path source selected)')}")
+    print(f"    {'Image base':<16} {record.image_base_address or '(unknown)'} (source: PEB)")
+    print()
+    for check in (_module_registration_check(mod_claim),
+                  _name_agreement_check(peb_claim, mod_claim),
+                  _pe_header_check(main_pe),
+                  _corroboration_check(mod_claim)):
+        _print_check(*check)
+
+    print(f"\n    {'Raw claims':<16} {'PEB':<32} ModuleList")
+    print(f"    {'path':<16} {(console_safe(peb_claim['image_path']) or '(none)'):<32} "
+          f"{console_safe(mod_claim['path']) or '(none)'}")
+    print(f"    {'name':<16} {(console_safe(peb_claim['name']) or '(none)'):<32} "
+          f"{console_safe(mod_claim['name']) or '(none)'}")
+    print(f"    {'image base':<16} {(peb_claim['image_base_address'] or '(none)'):<32} "
+          f"{mod_claim['base_address'] or '(none)'} ({mod_claim['match_state']})")
 
 
 def _render_extended_peb(peb_extended: dict) -> None:
     print(f"\n  {BOLD('Extended PEB')}")
     print(f"    {'PEB Address':<18} {peb_extended['peb_address'] or '(unknown)'}")
     print(f"    {'BeingDebugged':<18} {peb_extended['being_debugged']}")
-    print(f"    {'WindowTitle':<18} {peb_extended['window_title'] or '(none)'}")
-    print(f"    {'DllPath':<18} {peb_extended['dll_path'] or '(none)'}")
+    # WindowTitle/DllPath are PEB strings -- dump bytes, therefore
+    # attacker-controlled, exactly like the path/command line the default
+    # block above already escapes (#98). The record and --json keep the
+    # exact decoded value.
+    print(f"    {'WindowTitle':<18} {console_safe(peb_extended['window_title']) or '(none)'}")
+    print(f"    {'DllPath':<18} {console_safe(peb_extended['dll_path']) or '(none)'}")
     print(f"    {'StandardInput':<18} {peb_extended['standard_input'] or '(unknown)'}")
     print(f"    {'StandardOutput':<18} {peb_extended['standard_output'] or '(unknown)'}")
     print(f"    {'StandardError':<18} {peb_extended['standard_error'] or '(unknown)'}")

--- a/tests/integration/test_cli_v2_routing.py
+++ b/tests/integration/test_cli_v2_routing.py
@@ -53,8 +53,21 @@ def test_help_groups_commands_and_modifiers_and_hides_legacy_names(
     # mid-word at a hyphen -- "peb_extended" (an underscore, never
     # hyphen-broken by textwrap) is the resistant marker to check for.
     collapsed_help = " ".join(help_text.split())
+
+    def collapsed_verbose_help() -> str:
+        """The display-options group alone, reflowed onto one line:
+        argparse wraps at a width this test cannot control, so a
+        substring check against the raw text is width-dependent. Sliced
+        from the group heading, not from the first "--verbose" in the
+        text -- that one is in the usage line."""
+        start = collapsed_help.index("display options:")
+        return collapsed_help[start:collapsed_help.index("hunt options:", start)]
+
     assert "adds the retired" in collapsed_help
     assert "peb_extended" in collapsed_help
+    # #98: --verbose now also gates the --handles projection, and the
+    # help text has to say so -- passing it used to be silently ignored.
+    assert "--handles" in collapsed_verbose_help()
     # --sysinfo's own help text must reflect the removed Process section /
     # added Environment section, not the pre-#41 "process" summary.
     assert "Show OS, host, environment and CPU summary" in help_text
@@ -583,6 +596,53 @@ def test_handles_partial_json_exits_3(monkeypatch, tmp_path):
         assert doc["result"]["data"]["records"][0]["object_name_status"] == "unreadable"
     finally:
         os.remove(dump_path)
+
+
+def test_handles_verbose_is_wired_end_to_end_without_changing_the_json(monkeypatch, tmp_path, capsys):
+    """#98: `--handles --verbose` used to be silently ignored -- the CLI
+    never forwarded the flag. It must now reach the renderer, show the
+    rows the default projection folds, and leave the structured result
+    byte-identical."""
+    from tests.unit.test_handles_cmd import _mf_with
+    descriptors = ([{"handle": 0x10 + i, "type_name": "Event", "object_name": None}
+                    for i in range(4)]
+                   + [{"handle": 0x100, "type_name": "File",
+                       "object_name": r"\Device\HarddiskVolume1\notes.txt"}])
+    dump_path = _make_dump_file()
+    try:
+        monkeypatch.setattr(cli, "open_dump", lambda path: _mf_with(descriptors))
+
+        default_json = str(tmp_path / "default.json")
+        monkeypatch.setattr(sys, "argv", ["dumpex", dump_path, "--handles",
+                                          "--json", default_json])
+        cli.main()
+        default_console = capsys.readouterr().out
+
+        verbose_json = str(tmp_path / "verbose.json")
+        monkeypatch.setattr(sys, "argv", ["dumpex", dump_path, "--handles", "--verbose",
+                                          "--json", verbose_json])
+        cli.main()
+        verbose_console = capsys.readouterr().out
+    finally:
+        os.remove(dump_path)
+
+    default_doc = json.loads(open(default_json, encoding="utf-8").read())
+    verbose_doc = json.loads(open(verbose_json, encoding="utf-8").read())
+
+    # Console verbosity NEVER removes or mutates a structured record.
+    assert default_doc["result"]["data"] == verbose_doc["result"]["data"]
+    assert len(default_doc["result"]["data"]["records"]) == len(descriptors)
+    assert default_doc["result"]["coverage"] == verbose_doc["result"]["coverage"]
+    # ... and the flag IS recorded as an execution option either way.
+    assert default_doc["meta"]["execution"]["options"]["verbose"] is False
+    assert verbose_doc["meta"]["execution"]["options"]["verbose"] is True
+
+    # The console, and only the console, differs.
+    assert "not shown" in default_console
+    assert "use --verbose to show all" in default_console
+    assert "0x0000000000000010" not in default_console      # a folded anonymous Event
+    assert "0x0000000000000010" in verbose_console
+    assert "not shown" not in verbose_console
 
 
 class _FakeMinidumpHeader:

--- a/tests/unit/test_console_untrusted_text.py
+++ b/tests/unit/test_console_untrusted_text.py
@@ -278,22 +278,83 @@ def _case_sysinfo():
 # process_name/process_path/command_line come from the PEB (or, for the
 # name, the basename of a ModuleListStream path) -- §3.3's precedence
 # table. process_start_utc/image_base_address are dumpex-formatted.
+# The three top-level ProcessRecord strings hostile_record() can plant
+# directly. The verbose block's own dump-derived strings live inside
+# `iat`/`identity_evidence`/`peb_extended` (a tuple and two dicts, which
+# hostile_record() cannot fill field-by-field), so they are planted by
+# the builders below and checked by the whole-output sweep -- their
+# per-field reachability is asserted in tests/unit/test_process_cmd.py,
+# where the fixture can be the right shape.
 _PROCESS_FIELDS = ("process_name", "process_path", "command_line")
 
 
+def _hostile_iat() -> records_module.IatRecord:
+    """One import whose DLL and API names are dump strings (read out of
+    the image's import directory, #98's verbose table prints both)."""
+    entry = records_module.ImportEntryRecord(
+        dll=hostile_text_for("dll"), import_by="name", symbol=hostile_text_for("symbol"),
+        ordinal=None, iat_slot_va="0x0000000000401000",
+        resolved_target_va="0x00007ffb00001000", slot_in_bounds=False)
+    return records_module.IatRecord(
+        table_present=True, table_va="0x0000000000401000", table_size=8,
+        import_directory_present=True, import_directory_va="0x0000000000402000",
+        import_directory_size=40, has_entries=True, dll_count=1, entry_count=1,
+        entries=(entry,), diagnostics=())
+
+
+def _hostile_identity_evidence() -> dict:
+    """§3.4's claim block. Every string below is a PEB or
+    ModuleListStream value, and #98's `Identity Verification` block
+    prints all of them."""
+    return {
+        "misc_info_claim": {"pid": 1234, "process_create_time_utc": None,
+                            "raw_pid": 1234, "raw_process_create_time": None},
+        "peb_claim": {"image_base_address": "0x0000000000400000",
+                      "image_path": hostile_text_for("peb_image_path"),
+                      "name": hostile_text_for("peb_name"),
+                      "raw_image_base_address": None, "raw_image_path": None,
+                      "raw_command_line": None},
+        "module_claim": {"match_state": "unregistered", "base_address": None,
+                         "name": None, "path": None,
+                         "name_matched_candidate": {
+                             "base_address": "0x0000000000500000",
+                             "name": hostile_text_for("candidate_name"),
+                             "path": hostile_text_for("candidate_path")},
+                         "name_matched_candidate_ambiguous": False},
+        "main_image_pe": {"checked": True, "valid": False,
+                          "reason": hostile_text_for("pe_reason")},
+        "selected_path_source": "peb",
+        "diagnostics": [],
+    }
+
+
+def _hostile_peb_extended() -> dict:
+    """§3.6's verbose-only block: WindowTitle and DllPath are PEB
+    strings."""
+    return {"peb_address": "0x0000000000001000", "being_debugged": False,
+            "window_title": hostile_text_for("window_title"),
+            "dll_path": hostile_text_for("dll_path"),
+            "standard_input": None, "standard_output": None, "standard_error": None}
+
+
 def _case_process():
-    empty_iat = records_module.IatRecord(
-        table_present=False, table_va=None, table_size=None,
-        import_directory_present=False, import_directory_va=None,
-        import_directory_size=None, has_entries=False, dll_count=0,
-        entry_count=0, entries=(), diagnostics=())
+    """Rendered TWICE -- the default projection and `--verbose` -- and the
+    two outputs are swept together. The verbose block is the larger
+    surface by far (#98: the import table's DLL/API names, the identity
+    block's paths/names and PE rejection reason, and the Extended PEB's
+    window title and DLL path are all dump strings), and rendering only
+    the default view would leave every one of them unchecked."""
     record = hostile_record(records_module.ProcessRecord, dict(
         process_name="svchost.exe", pid=1234,
         process_path="C:\\Windows\\System32\\svchost.exe",
         command_line="svchost.exe -k netsvcs", process_start_utc="2024-01-01T00:00:00Z",
-        image_base_address="0x0000000000400000", iat=empty_iat,
-        identity_evidence={}), _PROCESS_FIELDS)
-    return _rendered(render_process_console, record, _coverage("process_identity"))
+        image_base_address="0x0000000000400000", iat=_hostile_iat(),
+        identity_evidence=_hostile_identity_evidence(),
+        peb_extended=_hostile_peb_extended()), _PROCESS_FIELDS)
+    coverage = _coverage("process_identity")
+    return (_rendered(render_process_console, record, coverage)
+            + _rendered(lambda rec, cov: render_process_console(rec, cov, verbose=True),
+                        record, coverage))
 
 
 # ModuleDiffRecord's name/full_path_* are ModuleListStream strings from

--- a/tests/unit/test_handles_cmd.py
+++ b/tests/unit/test_handles_cmd.py
@@ -125,11 +125,18 @@ def _limitation(coverage, code):
     return next((l for l in coverage.limitations if l.code == code), None)
 
 
-def _console(result) -> str:
+def _console(result, *, verbose=False) -> str:
     buffer = io.StringIO()
     with contextlib.redirect_stdout(buffer):
-        render_handles_console(result.records, result.coverage)
+        render_handles_console(result.records, result.coverage, verbose=verbose)
     return buffer.getvalue()
+
+
+def _rows(text: str) -> list:
+    """The table rows only -- every one starts with a fixed-width handle
+    value, which no other line in the block does."""
+    return [line for line in text.splitlines()
+            if line.strip().startswith("0x") and "  " in line.strip()]
 
 
 # ── §5.5 case 1: no HandleDataStream at all ─────────────────────────────
@@ -1049,3 +1056,245 @@ def test_collect_handles_never_routes_through_the_narrow_get_handles_view(monkey
     assert len(result.records) == 2
     assert _limitation(result.coverage,
                         LimitationCode.HANDLE_STREAM_TRUNCATED).affected_count == 3
+
+
+# ── #98: console folding is a projection, never a filter ────────────────
+# Every case here asserts the same underlying invariant from a different
+# side: the records, the summary and by_type are what collect_handles()
+# produced, whatever the console chose to print.
+
+# One anonymous handle of each foldable type, plus the investigation-
+# relevant anonymous types that must survive folding, plus a named row.
+_FOLDING_FIXTURE = (
+    [{"handle": 0x10 + i, "type_name": "Event", "object_name": None} for i in range(5)]
+    + [{"handle": 0x30 + i, "type_name": "Mutant", "object_name": None} for i in range(2)]
+    + [{"handle": 0x100, "type_name": "Process", "object_name": None},
+       {"handle": 0x110, "type_name": "Thread", "object_name": None},
+       {"handle": 0x120, "type_name": "Token", "object_name": None},
+       {"handle": 0x130, "type_name": "Section", "object_name": None},
+       {"handle": 0x140, "type_name": "Job", "object_name": None},
+       {"handle": 0x200, "type_name": "File", "object_name": "\\Device\\HarddiskVolume1\\a.txt"}]
+)
+
+
+def test_default_console_folds_only_approved_low_context_anonymous_rows():
+    result = collect_handles(_mf_with(_FOLDING_FIXTURE))
+    text = _console(result)
+    shown = "\n".join(_rows(text))
+
+    # Folded: anonymous Event/Mutant.
+    assert "Event" not in shown and "Mutant" not in shown
+    # Never folded: the anonymous types an investigation turns on.
+    for kept in ("Process", "Thread", "Token", "Section", "Job"):
+        assert kept in shown, f"{kept} was folded but must stay visible"
+    assert "\\Device\\HarddiskVolume1\\a.txt" in shown
+
+
+def test_default_console_reports_the_exact_folded_count_per_type():
+    text = _console(collect_handles(_mf_with(_FOLDING_FIXTURE)))
+    line = next(l for l in text.splitlines() if "not shown" in l)
+
+    assert "7 anonymous handle(s)" in line       # 5 Event + 2 Mutant
+    assert "Event 5" in line and "Mutant 2" in line
+    assert "use --verbose to show all" in text
+
+
+def test_folded_counts_are_ordered_count_desc_then_name_asc():
+    """§1.5's frozen order, applied to the fold line so two runs over the
+    same dump print the same text."""
+    descriptors = (
+        [{"handle": 0x10 + i, "type_name": "Mutant", "object_name": None} for i in range(3)]
+        + [{"handle": 0x40 + i, "type_name": "Event", "object_name": None} for i in range(3)]
+        + [{"handle": 0x80, "type_name": "Semaphore", "object_name": None}])
+    line = next(l for l in _console(collect_handles(_mf_with(descriptors))).splitlines()
+                if "not shown" in l)
+    listed = line.split("not shown:")[1]
+
+    assert listed.index("Event 3") < listed.index("Mutant 3") < listed.index("Semaphore 1")
+
+
+def test_verbose_console_shows_every_record_and_folds_nothing():
+    result = collect_handles(_mf_with(_FOLDING_FIXTURE))
+    text = _console(result, verbose=True)
+
+    assert len(_rows(text)) == len(result.records)
+    assert "not shown" not in text
+    assert "use --verbose to show all" not in text
+
+
+def test_verbosity_never_changes_the_records_the_summary_or_by_type():
+    """The console is a projection. Whatever it folds, the CommandResult
+    an analyst reads in --json is the same object either way."""
+    mf = _mf_with(_FOLDING_FIXTURE)
+    result = collect_handles(mf)
+    before = [r.to_dict() for r in result.records]
+    summary_before = dict(result.summary)
+
+    default_text = _console(result)
+    verbose_text = _console(result, verbose=True)
+
+    assert [r.to_dict() for r in result.records] == before
+    assert dict(result.summary) == summary_before
+    assert result.summary["count"] == len(_FOLDING_FIXTURE)
+    # The headline and the by_type line count the COMPLETE inventory in
+    # both projections -- a folded row is still captured evidence.
+    assert f"{len(_FOLDING_FIXTURE)} handle(s) captured" in default_text
+    assert f"{len(_FOLDING_FIXTURE)} handle(s) captured" in verbose_text
+    for text in (default_text, verbose_text):
+        by_type_line = next(l for l in text.splitlines() if "By type:" in l)
+        assert "Event 5" in by_type_line and "Mutant 2" in by_type_line
+
+
+def test_folding_never_hides_an_unreadable_name():
+    """"unnamed" and "unreadable" are different facts (§5.2.1): the
+    second is evidence LOSS, and folding it would hide the row an analyst
+    needs in order to know something was lost."""
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": "Event", "object_name": None},
+        {"handle": 0x20, "type_name": "Event", "object_name": BAD_RVA},
+        {"handle": 0x30, "type_name": BAD_RVA, "object_name": None},
+    ]))
+    shown = "\n".join(_rows(_console(result)))
+
+    assert "0x0000000000000020" in shown      # unreadable object name: kept
+    assert "0x0000000000000030" in shown      # unreadable TYPE name: kept
+    assert "0x0000000000000010" not in shown  # genuinely anonymous Event: folded
+
+
+def test_a_named_handle_of_a_foldable_type_is_never_folded():
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": "Event", "object_name": "\\BaseNamedObjects\\evil"},
+        {"handle": 0x20, "type_name": "Event", "object_name": None},
+    ]))
+    shown = "\n".join(_rows(_console(result)))
+    assert "\\BaseNamedObjects\\evil" in shown
+    assert "0x0000000000000020" not in shown
+
+
+def test_an_unknown_type_stays_visible_by_default():
+    """The fold list is an ALLOW list: a type nobody has classified --
+    including one a dump invents -- must default to being shown."""
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": "SomeFutureObjectType", "object_name": None},
+    ]))
+    assert "SomeFutureObjectType" in _console(result)
+
+
+def test_nothing_is_folded_when_no_row_qualifies():
+    result = collect_handles(_mf_with(_POPULATED))
+    assert "not shown" not in _console(result)
+
+
+def test_the_name_status_legend_explains_unnamed_versus_unreadable():
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": "Key", "object_name": None},
+    ]))
+    text = _console(result)
+    assert "(unnamed) = the descriptor records no name" in text
+    assert "(unreadable) = a name was recorded but the bounded read failed" in text
+
+
+def test_the_legend_is_absent_when_every_name_read():
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": "File", "object_name": "\\Device\\X"},
+    ]))
+    assert "the descriptor records no name" not in _console(result)
+
+
+# ── #98: NT namespace object names are explained, never expanded ────────
+
+def test_known_dlls_is_explained_as_an_nt_object_manager_directory():
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": "Directory", "object_name": "\\KnownDlls"},
+    ]))
+    text = _console(result)
+
+    assert "NT Object Manager directory" in text
+    assert "\\KnownDlls (Directory)" in text
+    # The note must not claim the directory's contents were captured, and
+    # nothing may be enumerated from the analysis host.
+    assert "not captured" in text
+    for forbidden in ("contains:", "entries:", "ntdll.dll", "kernel32.dll"):
+        assert forbidden not in text
+
+
+def test_a_directory_note_is_not_attached_to_a_handle_of_another_type():
+    """A dump can name a File handle "\\KnownDlls". Attaching the
+    directory note to it would be dumpex asserting something the
+    descriptor does not say."""
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": "File", "object_name": "\\KnownDlls"},
+    ]))
+    text = _console(result)
+    assert "\\KnownDlls" in text                            # the name is still shown
+    assert "pre-mapped system DLL sections" not in text     # the note is not
+
+
+def test_an_unlisted_directory_gets_one_generic_note_however_many_there_are():
+    """Bounded output: the notes block can never grow with the dump."""
+    descriptors = [{"handle": 0x10 + i, "type_name": "Directory",
+                    "object_name": f"\\Sessions\\{i}\\BaseNamedObjects"} for i in range(50)]
+    text = _console(collect_handles(_mf_with(descriptors)))
+    generic = [l for l in text.splitlines()
+               if "Directory handles name an NT Object Manager namespace directory" in l]
+    assert len(generic) == 1
+
+
+def test_a_note_survives_its_row_being_folded():
+    """A folded row is still captured evidence, so a note derived from it
+    must not disappear with the row. (Directory is not foldable today;
+    the notes are built from the COLLECTED records so this holds however
+    the fold list changes.)"""
+    import dumpex.commands.handles as handles_module
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": "Directory", "object_name": "\\KnownDlls"},
+    ]))
+    text = _console(result)
+    assert "NT Object Manager directory" in text
+
+    original = handles_module._FOLDABLE_ANONYMOUS_TYPES
+    try:
+        handles_module._FOLDABLE_ANONYMOUS_TYPES = frozenset(original | {"Directory"})
+        assert "NT Object Manager directory" in _console(result)
+    finally:
+        handles_module._FOLDABLE_ANONYMOUS_TYPES = original
+
+
+def test_the_notes_block_escapes_its_own_labels():
+    """The label carries a dump-derived object name, so it is the same
+    attack surface as the table."""
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": "Directory", "object_name": "A\x1b[31mB"},
+    ]))
+    text = _console(result)
+    assert "\x1b[31m" not in text
+
+
+def test_folding_and_notes_never_imply_live_state():
+    result = collect_handles(_mf_with(_FOLDING_FIXTURE + [
+        {"handle": 0x500, "type_name": "Directory", "object_name": "\\KnownDlls"}]))
+    for text in (_console(result), _console(result, verbose=True)):
+        lowered = text.lower()
+        for forbidden in ("current", "live", "open process", "running process", "now holds"):
+            assert forbidden not in lowered
+
+
+def test_cmd_handles_forwards_verbose_to_the_renderer_only():
+    """--verbose reaches the renderer; the collector has no verbosity
+    parameter at all, which is what makes "console filtering never
+    removes a record from --json" structural."""
+    import inspect
+    assert "verbose" not in inspect.signature(collect_handles).parameters
+
+    mf = _mf_with(_FOLDING_FIXTURE)
+    default_buf, verbose_buf = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(default_buf):
+        default_result = cmd_handles(mf)
+    with contextlib.redirect_stdout(verbose_buf):
+        verbose_result = cmd_handles(mf, verbose=True)
+
+    assert ([r.to_dict() for r in default_result.records]
+            == [r.to_dict() for r in verbose_result.records])
+    assert default_result.summary == verbose_result.summary
+    assert default_result.coverage.status == verbose_result.coverage.status
+    assert len(_rows(verbose_buf.getvalue())) > len(_rows(default_buf.getvalue()))

--- a/tests/unit/test_process_cmd.py
+++ b/tests/unit/test_process_cmd.py
@@ -10,6 +10,7 @@ so no real .dmp is required.
 import io
 import struct
 import contextlib
+import dataclasses
 
 import pytest
 
@@ -19,7 +20,11 @@ from tests.fixtures.fakes import (
 )
 
 from dumpex.commands.process import collect_process, cmd_process, render_process_console
-from dumpex.output.coverage import exit_code_for, CoverageStatus, LimitationCode, render_limitation
+from dumpex.output import records as records_module
+from dumpex.output.coverage import (
+    build_coverage_report, exit_code_for, CoverageStatus, LimitationCode, render_limitation,
+    SourceObservation, SourceState,
+)
 
 
 IMAGE_BASE = 0x00007ff600010000
@@ -1410,20 +1415,352 @@ def test_collect_process_is_deterministic_across_calls():
     assert first == second
 
 
-# ── --verbose rendering ────────────────────────────────────────────────
+# ── #98 console-projection helpers ──────────────────────────────────────
+# These build a ProcessRecord DIRECTLY rather than going through a fake
+# dump, for the cases whose whole point is a rendering decision over a
+# particular identity_evidence shape (an unregistered base with an
+# ambiguous name candidate, a PE header that was never checked, a
+# hostile string in one specific field). Driving those from dump bytes
+# would need a fixture per case and would still only reach the renderer
+# through the same record.
 
-def test_verbose_console_prints_iat_table_evidence_matrix_and_extended_peb():
-    mf = _complete_mf()
-    result = collect_process(mf, verbose=True)
+
+def _rendered(result, *, verbose=False) -> str:
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
-        render_process_console(result.records[0], result.coverage, verbose=True)
-    out = buf.getvalue()
+        render_process_console(result.records[0], result.coverage, verbose=verbose)
+    return buf.getvalue()
+
+
+def _rendered_record(record, *, verbose=False) -> str:
+    coverage = build_coverage_report({"process_identity": SourceObservation(
+        name="process_identity", state=SourceState.PRESENT, record_count=1)})
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        render_process_console(record, coverage, verbose=verbose)
+    return buf.getvalue()
+
+
+def _identity_evidence(*, peb_path=r"C:\Samples\malware.exe", peb_name="malware.exe",
+                       module_path=r"C:\Samples\malware.exe", module_name="malware.exe",
+                       match_state="resolved", ambiguous=False, candidate=None,
+                       main_image_pe=None, selected_path_source="peb") -> dict:
+    return {
+        "misc_info_claim": {"pid": 4242, "process_create_time_utc": None,
+                            "raw_pid": 4242, "raw_process_create_time": None},
+        "peb_claim": {"image_base_address": "0x00007ff600010000", "image_path": peb_path,
+                      "name": peb_name, "raw_image_base_address": None,
+                      "raw_image_path": None, "raw_command_line": None},
+        "module_claim": {"match_state": match_state,
+                         "base_address": ("0x00007ff600010000"
+                                          if match_state == "resolved" else None),
+                         "name": module_name, "path": module_path,
+                         "name_matched_candidate": candidate,
+                         "name_matched_candidate_ambiguous": ambiguous},
+        "main_image_pe": main_image_pe or {"checked": True, "valid": True, "reason": None},
+        "selected_path_source": selected_path_source,
+        "diagnostics": [],
+    }
+
+
+def _process_record(*, entries=(), identity_evidence=None, peb_extended=None,
+                    process_path=r"C:\Samples\malware.exe", process_name="malware.exe"):
+    iat = records_module.IatRecord(
+        table_present=bool(entries),
+        table_va="0x00007ff600021000" if entries else None,
+        table_size=(8 * len(entries)) or None,
+        import_directory_present=bool(entries),
+        import_directory_va="0x00007ff600020000" if entries else None,
+        import_directory_size=40 if entries else None, has_entries=bool(entries),
+        dll_count=len({e.dll for e in entries}) if entries else 0,
+        entry_count=len(entries), entries=tuple(entries), diagnostics=())
+    return records_module.ProcessRecord(
+        process_name=process_name, pid=4242, process_path=process_path,
+        command_line=r'"C:\Samples\malware.exe" -k',
+        process_start_utc="2026-08-14 01:15:05 UTC",
+        image_base_address="0x00007ff600010000", iat=iat,
+        identity_evidence=identity_evidence or _identity_evidence(),
+        peb_extended=peb_extended)
+
+
+def _process_record_with_entries(entries):
+    return _process_record(entries=entries)
+
+
+def _identity_record(*, peb_name, module_name, match_state, ambiguous=False,
+                     main_image_pe=None):
+    candidate = None
+    if match_state == "unregistered" and ambiguous:
+        candidate = {"base_address": "0x00007ff700000000", "name": peb_name,
+                     "path": r"C:\Windows\Temp\%s" % peb_name}
+    return _process_record(identity_evidence=_identity_evidence(
+        peb_name=peb_name, module_name=module_name, match_state=match_state,
+        ambiguous=ambiguous, candidate=candidate, main_image_pe=main_image_pe))
+
+
+def _empty_peb_extended(**overrides) -> dict:
+    base = {"peb_address": "0x0000000000001000", "being_debugged": False,
+            "window_title": None, "dll_path": None, "standard_input": None,
+            "standard_output": None, "standard_error": None}
+    base.update(overrides)
+    return base
+
+
+def _hostile_verbose_record(field: str, hostile: str):
+    """One record with `hostile` planted in exactly one dump-derived
+    field, so a passing case names the field that is actually escaped
+    rather than averaging several together."""
+    identity_kwargs = {}
+    peb_extended = _empty_peb_extended()
+    entry_kwargs = {"dll": "KERNEL32.dll", "import_by": "name", "symbol": "CreateFileW",
+                    "ordinal": None, "iat_slot_va": "0x00007ff600021018",
+                    "resolved_target_va": "0x00007ffb12345678", "slot_in_bounds": True}
+    if field == "peb_path":
+        identity_kwargs["peb_path"] = hostile
+    elif field == "peb_name":
+        identity_kwargs["peb_name"] = hostile
+        identity_kwargs["module_name"] = "malware.exe"
+    elif field == "module_path":
+        identity_kwargs["module_path"] = hostile
+    elif field == "module_name":
+        identity_kwargs["module_name"] = hostile
+    elif field == "pe_reason":
+        identity_kwargs["main_image_pe"] = {"checked": True, "valid": False,
+                                            "reason": hostile}
+    elif field == "window_title":
+        peb_extended = _empty_peb_extended(window_title=hostile)
+    elif field == "dll_path":
+        peb_extended = _empty_peb_extended(dll_path=hostile)
+    elif field in ("dll", "symbol"):
+        entry_kwargs[field] = hostile
+    else:                                        # pragma: no cover -- guard
+        raise AssertionError(f"unknown field {field!r}")
+
+    entry = records_module.ImportEntryRecord(**entry_kwargs)
+    record = _process_record(entries=[entry],
+                             identity_evidence=_identity_evidence(**identity_kwargs),
+                             peb_extended=peb_extended)
+    # The record layer must keep the exact decoded value -- escaping is a
+    # console projection, and --json is where evidence is read.
+    if field in ("dll", "symbol"):
+        assert getattr(record.iat.entries[0], field) == hostile
+    return record
+
+
+# ── --verbose rendering ────────────────────────────────────────────────
+
+def test_verbose_console_prints_iat_table_identity_checks_and_extended_peb():
+    mf = _complete_mf()
+    result = collect_process(mf, verbose=True)
+    out = _rendered(result, verbose=True)
     assert "KERNEL32.dll" in out
     assert "CreateFileW" in out
-    assert "Evidence Matrix" in out
+    assert "Identity Verification" in out
     assert "Extended PEB" in out
-    assert "main-image PE: valid" in out
+    assert "[OK] a valid PE header was found at the PEB image base" in out
+
+
+# ── #98: the verbose IAT table explains its own address pair ────────────
+
+def test_verbose_iat_table_has_headers_for_all_four_columns():
+    """The pre-#98 rendering was `<address> -> <address>` with no header
+    and no legend, so which of the two was the slot and which the target
+    was only recoverable from the source."""
+    mf = _complete_mf()
+    result = collect_process(mf, verbose=True)
+    out = _rendered(result, verbose=True)
+
+    header = next(l for l in out.splitlines() if "IAT Slot VA" in l and "DLL" in l)
+    for column in ("DLL", "Imported API", "IAT Slot VA", "Resolved Target VA"):
+        assert column in header
+    assert header.index("DLL") < header.index("Imported API") < \
+           header.index("IAT Slot VA") < header.index("Resolved Target VA")
+
+
+def test_verbose_iat_legend_states_which_address_is_which():
+    mf = _complete_mf()
+    result = collect_process(mf, verbose=True)
+    out = " ".join(_rendered(result, verbose=True).split())
+
+    assert "IAT Slot VA -> Resolved Target VA" in out
+    assert "the slot is the address where the import pointer is stored" in out.lower()
+    assert "the target is the address stored in that slot" in out.lower()
+
+
+def test_verbose_iat_row_keeps_the_slot_and_target_in_their_own_columns():
+    mf = _complete_mf()
+    result = collect_process(mf, verbose=True)
+    entry = result.records[0].iat.entries[0]
+    out = _rendered(result, verbose=True)
+
+    row = next(l for l in out.splitlines() if entry.iat_slot_va in l and "KERNEL32" in l)
+    tokens = row.split()
+    assert tokens.index(entry.iat_slot_va) < tokens.index(entry.resolved_target_va)
+    # The addresses are two independent tokens, never fused by a column
+    # that ran out of width.
+    assert f"{entry.iat_slot_va}{entry.resolved_target_va}" not in row
+
+
+def test_verbose_iat_marks_an_out_of_bounds_slot_without_calling_it_a_verdict():
+    """`slot_in_bounds is False` is an observation (§3.5.5 files it as a
+    diagnostic, never a limitation). It must be visible in the table, and
+    it must not read as a hooking verdict or a coverage failure."""
+    entry = records_module.ImportEntryRecord(
+        dll="KERNEL32.dll", import_by="name", symbol="CreateFileW", ordinal=None,
+        iat_slot_va="0x00007ff600021018", resolved_target_va="0x00007ffb12345678",
+        slot_in_bounds=False)
+    in_bounds = dataclasses.replace(entry, symbol="CloseHandle", slot_in_bounds=True)
+    record = _process_record_with_entries([entry, in_bounds])
+
+    out = _rendered_record(record, verbose=True)
+    marked = next(l for l in out.splitlines() if "CreateFileW" in l)
+    unmarked = next(l for l in out.splitlines() if "CloseHandle" in l)
+    assert marked.rstrip().endswith("*")
+    assert not unmarked.rstrip().endswith("*")
+    assert "outside the recorded import directory bounds" in " ".join(out.split())
+    for verdict in ("hook", "malicious", "suspicious", "tamper"):
+        assert verdict not in out.lower()
+
+
+def test_verbose_iat_footnote_is_absent_when_every_slot_is_in_bounds():
+    record = _process_record_with_entries([records_module.ImportEntryRecord(
+        dll="KERNEL32.dll", import_by="name", symbol="CloseHandle", ordinal=None,
+        iat_slot_va="0x00007ff600021018", resolved_target_va="0x00007ffb12345678",
+        slot_in_bounds=True)])
+    out = _rendered_record(record, verbose=True)
+    assert "outside the recorded import directory" not in out
+    assert "*" not in out
+
+
+# ── #98: Identity Verification replaces the Evidence Matrix ─────────────
+
+def test_identity_block_shows_the_selected_value_not_the_source_name():
+    """The old matrix printed "peb" in a column headed `Selected`, i.e. a
+    SOURCE NAME where a reader expects the selected VALUE."""
+    mf = _complete_mf()
+    result = collect_process(mf, verbose=True)
+    out = _rendered(result, verbose=True)
+
+    selected = next(l for l in out.splitlines() if "Selected path" in l)
+    assert r"C:\Samples\malware.exe" in selected
+    assert selected.split()[2] != "peb"
+    source = next(l for l in out.splitlines() if l.strip().startswith("Source"))
+    assert "PEB" in source
+
+
+def test_identity_block_states_each_check_as_a_conclusion():
+    mf = _complete_mf()
+    result = collect_process(mf, verbose=True)
+    out = _rendered(result, verbose=True)
+
+    assert "[OK] PEB image base is registered in ModuleList" in out
+    assert "[OK] PEB and ModuleList process names agree" in out
+    assert "[OK] a valid PE header was found at the PEB image base" in out
+    assert "[OK] no competing module shares this process name" in out
+    # The internal claim vocabulary is no longer the LEAD, but the raw
+    # per-source claims stay available underneath.
+    assert "Raw claims" in out
+    assert "(resolved)" in out
+
+
+def test_identity_block_renders_an_unregistered_base_as_a_conflict_not_a_verdict():
+    misc = MiscInfo(process_id=4242, process_create_time=1786670105)
+    peb = Peb(IMAGE_BASE, r"C:\Samples\malware.exe", command_line=r"C:\Samples\malware.exe")
+    other_base = 0x00007ff700000000
+    mod = Module(other_base, 0x6000, r"C:\Windows\Temp\malware.exe")
+    mf = _mf(misc_info=misc, peb=peb, modules=[mod], memory=_build_valid_image_no_imports())
+
+    result = collect_process(mf, verbose=True)
+    out = _rendered(result, verbose=True)
+
+    assert "[!!] no module is registered at the PEB image base" in out
+    assert "0x00007ff700000000" in out          # the competing registration
+    # An identity conflict is an observation: it never becomes a verdict,
+    # a trust boolean, or a coverage/exit-code change.
+    assert "peb_trusted" not in out
+    for verdict in ("malicious", "injected", "hollowed"):
+        assert verdict not in out.lower()
+    assert result.coverage.status == collect_process(mf).coverage.status
+
+
+def test_identity_block_reports_unavailable_checks_as_unavailable():
+    """Absent ModuleListStream: every ModuleList-dependent check has to
+    read as "could not be evaluated", never as agreement and never as a
+    conflict."""
+    misc = MiscInfo(process_id=4242, process_create_time=1786670105)
+    peb = Peb(IMAGE_BASE, r"C:\Samples\malware.exe", command_line=r"C:\Samples\malware.exe")
+    mf = _mf(misc_info=misc, peb=peb, memory=_build_valid_image_no_imports())
+
+    result = collect_process(mf, verbose=True)
+    out = _rendered(result, verbose=True)
+
+    assert "[--] PEB image base could not be compared with ModuleList" in out
+    assert "[--] PEB and ModuleList process names could not be compared" in out
+    assert "PEB and ModuleList process names agree" not in out
+
+
+def test_identity_name_agreement_ignores_case_only_differences():
+    """Windows module and file names are case-insensitive, so a case
+    difference alone must not be reported to an analyst as a conflict."""
+    record = _identity_record(peb_name="Malware.exe", module_name="malware.exe",
+                              match_state="resolved")
+    out = _rendered_record(record, verbose=True)
+    assert "[OK] PEB and ModuleList process names agree" in out
+
+
+def test_identity_name_disagreement_shows_both_values():
+    record = _identity_record(peb_name="malware.exe", module_name="svchost.exe",
+                              match_state="resolved")
+    out = _rendered_record(record, verbose=True)
+    assert "[!!] PEB and ModuleList process names differ" in out
+    assert "malware.exe" in out and "svchost.exe" in out
+
+
+def test_identity_block_reports_an_ambiguous_name_candidate():
+    record = _identity_record(peb_name="malware.exe", module_name=None,
+                              match_state="unregistered", ambiguous=True)
+    out = _rendered_record(record, verbose=True)
+    assert "[!!] more than one module shares this process name" in out
+
+
+def test_identity_block_reports_an_invalid_pe_header_with_its_reason():
+    record = _identity_record(peb_name="malware.exe", module_name="malware.exe",
+                              match_state="resolved",
+                              main_image_pe={"checked": True, "valid": False,
+                                             "reason": "no PE\0\0 signature at e_lfanew"})
+    out = _rendered_record(record, verbose=True)
+    assert "[!!] no valid PE header at the PEB image base" in out
+    assert "e_lfanew" in out
+
+
+def test_identity_block_reports_an_unchecked_pe_header_as_unavailable():
+    record = _identity_record(peb_name="malware.exe", module_name="malware.exe",
+                              match_state="resolved",
+                              main_image_pe={"checked": False, "valid": None, "reason": None})
+    out = _rendered_record(record, verbose=True)
+    assert "[--] the PEB image base was not checked for a PE header" in out
+
+
+# ── #98: every dump-derived verbose string is console-escaped ───────────
+
+@pytest.mark.parametrize("hostile,escaped", [
+    ("evil\n  [~] forged coverage reason", "\\x0a"),
+    ("evil\x1b[2Jcleared", "\\x1b"),
+    ("user\u202egnp.exe", "\\u202e"),
+])
+@pytest.mark.parametrize("field", ["peb_path", "peb_name", "module_path", "module_name",
+                                   "pe_reason", "window_title", "dll_path", "dll", "symbol"])
+def test_verbose_process_strings_cannot_drive_the_terminal(field, hostile, escaped):
+    """Newline/ANSI/bidi regression coverage for every dump-derived
+    string the verbose renderer prints -- the identity block's paths and
+    names, the PE rejection reason, the Extended PEB window title and DLL
+    path, and the import table's DLL/API names."""
+    record = _hostile_verbose_record(field, hostile)
+    out = _rendered_record(record, verbose=True)
+
+    assert hostile not in out               # never verbatim
+    assert escaped in out                   # rendered visibly instead
+    assert not any(line.strip().startswith("[~] forged") for line in out.splitlines())
 
 
 def test_verbose_console_renders_ordinal_and_unavailable_import_entries():


### PR DESCRIPTION
Console-presentation only. No JSON record shape, coverage meaning, limitation code, diagnostic, ordering rule, or exit code changed, and v2.13's schema and the frozen historical schemas/fixtures are untouched -- --json output is byte-identical across this change.

--handles --verbose is wired end-to-end. It parsed before, but the CLI dispatch never forwarded it, so passing it had no effect at all.

The default --handles console folds routine anonymous rows into per-type counts, states the exact omitted total, and names --verbose as the way to see them. Folding is a projection, never a filter: collect_handles() takes no verbosity parameter, so the records, summary, by_type, coverage and exit code are identical in both views. A row folds only when its object name is positively "unnamed" AND its captured type is on an explicit allow list of low-context synchronization primitives -- an unreadable name is evidence loss and never folds, anonymous Process/ Thread/Token/Section/Job handles never fold, and an unclassified type stays visible.

(unnamed) vs (unreadable) is explained inline, and captured NT Object Manager names get bounded, type-keyed notes: \KnownDlls reads as the Object Manager directory it is, without claiming its contents were captured and without expanding anything from the analysis host.

--process --verbose now explains its own addresses: the import table has DLL / Imported API / IAT Slot VA / Resolved Target VA headers plus a legend for the pair, and an out-of-bounds slot is a marked observation with a footnote, not a hooking verdict.

Evidence Matrix becomes Identity Verification: the selected value and its source are separate lines (the old block printed the source name "peb" in a column headed Selected), and each of the four identity checks reports [OK], [!!] or [--] with the raw per-source claims kept beneath. Names are compared case-insensitively. An identity disagreement stays an observation -- no verdict, no peb_trusted boolean, no coverage or exit-code change.

Every dump-derived string the verbose process renderer prints -- both paths, both names, the PE rejection reason, the import table's DLL/API names, and the Extended PEB's window title and DLL path -- now goes through console_safe(), with newline/ANSI/bidi regression coverage.

Contract doc goes to rev6 (new §3.8.1/§3.8.2 and §5.6.1-§5.6.3), plus coordinated CLI reference, SOC quickstart and CHANGELOG updates.