### PR TITLE
fix(recon): fold anonymous handles by default and align both consoles (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,24 +19,26 @@ forwarded it, so passing it had no effect at all. It is now wired through
 the dispatch, the command boundary, the renderer, the help text and
 `meta.execution.options`.
 
-**The default `--handles` console folds routine anonymous rows.** Rows
-whose object name the descriptor positively records as absent, and whose
-type is a low-context synchronization primitive (`Event`, `Mutant`,
-`Semaphore`, `Timer`, `IoCompletion`, `WaitCompletionPacket`, and
-similar), collapse into per-type counts:
+**The default `--handles` console folds anonymous rows.** Every row whose
+object name the descriptor positively records as absent collapses into a
+per-type count:
 
 ```text
-  11 anonymous handle(s) of routine low-context type(s) not shown: Event 9, Mutant 2
+  13 anonymous handle(s) not shown (no object name recorded): Event 9, Semaphore 3, Key 1
   These rows are captured evidence and are complete in structured output -- use --verbose to show all.
 ```
 
 Folding is a **projection, never a filter**: the folded rows are still
 counted in the headline and the `By type:` line, still in `summary`, and
-still in `--json`. Anonymous `Process`, `Thread`, `Token`, `Section` and
-`Job` handles are never folded — an anonymous handle to one of those is
-exactly the evidence a cross-process access question turns on — and
-neither is any row whose name could not be read. The type list is an
-allow list, so an unclassified (or dump-invented) type stays visible.
+still in `--json`, and the fold line always names each type and its exact
+count, so nothing disappears unnamed.
+
+Two kinds of row never fold. Anonymous `Process`, `Thread`, `Token`,
+`Section` and `Job` handles stay visible however many a dump carries —
+an anonymous handle to one of those is exactly the evidence a
+cross-process access question turns on. Neither does any row whose type
+or object name could not be **read**: that is evidence loss, and hiding
+it would hide the one row saying something was lost.
 
 **`(unnamed)` versus `(unreadable)` is now explained inline**, and common
 NT Object Manager names get a bounded note. `\KnownDlls` reads as what it
@@ -44,6 +46,19 @@ is — an Object Manager directory whose name this descriptor recorded, not
 a filesystem path and not a list of DLLs — without claiming the objects
 inside it were captured. dumpex never expands such a directory from the
 analysis host.
+
+**Both console tables are now aligned, not merely separated.** A
+per-column width in a format string is a minimum, not a truncation, so a
+single 20-character type name (`WaitCompletionPacket`,
+`IoCompletionReserve`, …) or a long API-set DLL name pushed that one
+row's remaining columns right while every other row stayed put — the
+table read as ragged under its own header, and a column-wise read or a
+copy-paste into a report was worthless. Every column in the `--handles`
+table and in the verbose `--process` import table is now sized to the
+widest value it actually holds, so all rows line up with each other and
+with the header. Nothing is truncated, and a cap keeps one
+attacker-controlled 4,000-character name from padding every row in the
+table.
 
 **`--process --verbose` explains its own addresses.** The import table
 used to print `<address> -> <address>` with no header and no legend, so

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -168,14 +168,11 @@ always the complete, lossless evidence surface.
 
 ### `--handles`
 
-The default console folds routine **anonymous** handle rows — rows whose
-object name the descriptor positively records as absent, and whose type
-is a low-context synchronization primitive (`Event`, `Mutant`,
-`Semaphore`, `Timer`, `IoCompletion`, and similar) — into per-type
-counts:
+The default console folds **anonymous** handle rows — rows whose object
+name the descriptor positively records as absent — into per-type counts:
 
 ```text
-  11 anonymous handle(s) of routine low-context type(s) not shown: Event 9, Mutant 2
+  13 anonymous handle(s) not shown (no object name recorded): Event 9, Semaphore 3, Key 1
   These rows are captured evidence and are complete in structured output -- use --verbose to show all.
 ```
 
@@ -183,7 +180,10 @@ Those rows are still captured, still counted in the headline and the
 `By type:` line, and still in `--json`. `--verbose` prints all of them.
 
 Anonymous `Process`, `Thread`, `Token`, `Section` and `Job` handles are
-**never** folded, and neither is any row whose name could not be read.
+**never** folded — those are the ones a cross-process access question
+turns on — and neither is any row whose name could not be read. Every
+other anonymous type folds, and the fold line always names the type and
+its exact count, so nothing disappears unnamed.
 The two states are different facts and the console keeps them apart:
 
 - `(unnamed)` — the descriptor records no name. Nothing was lost.

--- a/docs/SOC_QUICKSTART.md
+++ b/docs/SOC_QUICKSTART.md
@@ -42,10 +42,10 @@ command's output:
   means a name should have been there and the bounded read failed —
   evidence was lost, and it is reported as a coverage limitation.
 
-`--handles` folds routine anonymous rows (anonymous `Event`, `Mutant`,
-`Semaphore`, and similar low-context types) into per-type counts and
-tells you how many it folded; run it again with `--verbose` for the full
-inventory. Anonymous `Process`, `Thread`, `Token`, `Section` and `Job`
+`--handles` folds anonymous rows — every row whose descriptor recorded no
+object name — into per-type counts, naming each type and its exact count,
+and tells you how many it folded; run it again with `--verbose` for the
+full inventory. Anonymous `Process`, `Thread`, `Token`, `Section` and `Job`
 handles are never folded — those are the ones a cross-process access
 question turns on. A name like `\KnownDlls` is a real NT Object Manager
 **directory**, not a filesystem path; the descriptor records the

--- a/docs/recon_process_sysinfo_handles_contract.md
+++ b/docs/recon_process_sysinfo_handles_contract.md
@@ -1646,7 +1646,13 @@ was which was recoverable only from the source. Frozen layout:
 ```
 
 - The four column headers are frozen: `DLL`, `Imported API`,
-  `IAT Slot VA`, `Resolved Target VA`.
+  `IAT Slot VA`, `Resolved Target VA`. Each is sized to the widest value
+  it actually holds in that render, floored at a minimum (24 / 28 / 20)
+  and capped above (48 / 64), by the same `column_width()` rule §5.6
+  applies to the handle table — a fixed minimum separates a table
+  without aligning it, and `dll`/`symbol` are dump-derived, so one long
+  API-set DLL name would otherwise leave every other row ragged and one
+  hostile name would set the layout for all of them.
 - §3.5.3's three import states stay distinct and are read from
   `import_by`, never inferred from a null `symbol`: a name, `ordinal
   #N`, and `(unavailable)` (the loader had already overwritten
@@ -2728,17 +2734,43 @@ reduction path is introduced.
   the distinction the record does (§5.2.1), so a reader scanning the
   table is never told a handle is anonymous when its name was lost, and
   a handle with one good name and one lost one shows both truthfully.
-- Every column width is a **minimum**, never a truncation: a value wider
-  than its column pushes the rest of the row right rather than losing
-  characters. Each column is therefore followed by two **literal**
-  spaces, so the separator survives an oversized value — a width alone
-  does not. Windows carries plenty of 16-to-20-character type names
-  (`WaitCompletionPacket`, `FilterConnectionPort`, `IoCompletionReserve`,
-  …), which a separator-less `Type` column fuses to the `Access` mask
-  into one unsplittable token. `Access` gets the same treatment even
-  though a raw 32-bit mask cannot overflow it: §5.2's deferred
-  type-specific permission decoding would put a decoded name there, and
-  the same fusion would reappear one column over.
+- **A value is never truncated, and the table is nevertheless aligned.**
+  Each column is sized to the widest value it actually holds in that
+  render, floored at a frozen minimum (`Type` 14, `Access` 10, the two
+  counters 3) and capped above (`Type` 40, `Access` 32). Every column is
+  still followed by two **literal** spaces, so two values can never fuse
+  into one unsplittable token.
+
+  A per-column minimum width **separates** a table without **aligning**
+  it, and that distinction is the whole point: a width in a format spec
+  is a minimum, not a truncation, so one 20-character type name — and
+  Windows carries plenty (`WaitCompletionPacket`,
+  `FilterConnectionPort`, `IoCompletionReserve`, …) — pushes that ONE
+  row's `Access`/`Cnt`/`Ptr`/`Object` right while every other row stays
+  put. The table then reads as ragged under its own header, and a
+  column-wise read (or `awk`, or a copy-paste into a report) is
+  worthless. Measuring the column instead lines every row up with every
+  other row and with the header, and still drops no characters.
+
+  Widths are measured on the **escaped, projected** strings that are
+  actually printed, never on the raw record values: `console_safe()`
+  expands a name, and a column sized on the unescaped value would be too
+  narrow for its own row.
+
+  The caps are the safety valve, because type and object names are
+  attacker-controlled: without a ceiling, one 4,000-character name would
+  pad **every** row to 4,000 columns and destroy the table for the other
+  handles. A value past the cap is still printed in full — its own row
+  overflows and pushes right, which is the ordinary fixed-width
+  behaviour, now confined to the pathological case instead of being the
+  normal one. Both caps sit far above any real Windows object type name.
+  `Access` is measured like the rest even though a raw 32-bit mask
+  cannot overflow it: §5.2's deferred type-specific permission decoding
+  would put a decoded name there.
+
+  The single width rule is `column_width()` in
+  `dumpex/ui/console_layout.py`, shared with §3.8.1's import table so the
+  two console tables cannot drift apart.
 - `summary = {"count": N, "by_type": {…}}`, with `by_type` keyed by
   `type_name`, ordered count-descending then name-ascending (§1.5).
   A `null` `type_name` is keyed `"(unnamed)"` or `"(unreadable)"`
@@ -2783,7 +2815,7 @@ per-type counts, and `--verbose` renders every record.
   0x0000000000000300  Process         0x001fffff    1    1  (unnamed)
   (unnamed) = the descriptor records no name; (unreadable) = a name was recorded but the bounded read failed
 
-  11 anonymous handle(s) of routine low-context type(s) not shown: Event 9, Mutant 2
+  13 anonymous handle(s) not shown (no object name recorded): Event 9, Semaphore 3, Key 1
   These rows are captured evidence and are complete in structured output -- use --verbose to show all.
 ```
 
@@ -2793,27 +2825,33 @@ per-type counts, and `--verbose` renders every record.
   identical in both views. A folded row remains captured, normalized,
   counted, and present in `--json`. The headline and the `By type:` line
   always describe the **complete** inventory.
-- A row is folded only when **both** hold:
-  1. `object_name_status == "unnamed"` — the descriptor positively
-     records no object name. `"unreadable"` is evidence **loss** and is
-     never folded, in either name field: folding it would hide the one
-     row that says something was lost.
-  2. its captured `type_name` is on an explicitly approved list of
-     low-context types (synchronization/scheduling primitives whose
-     anonymous instances carry no name, path, or cross-process
-     reference: `Event`, `EtwRegistration`, `IoCompletion`,
-     `IoCompletionReserve`, `IRTimer`, `Mutant`, `Semaphore`, `Timer`,
-     `TpWorkerFactory`, `WaitCompletionPacket`).
-- `object_name_status == "unnamed"` alone is **not** a sufficient
-  suppression rule. An anonymous `Process`, `Thread`, `Token`,
-  `Section`, or `Job` handle is exactly the evidence a cross-process
-  access question turns on, and none of them are foldable.
-- The list is an **allow** list: an unclassified type — including one a
-  dump invents — stays visible. The failure mode of a new Windows object
-  type is a slightly longer table, never a hidden handle.
-- The fold line states the exact total and the per-type counts, ordered
-  by §1.5 (count descending, then type name ascending), and names
-  `--verbose` as the way to see them. Folding is deterministic, bounded,
+- An anonymous row folds **unless** one of two things holds:
+  1. **the row lost evidence.** `object_name_status == "unreadable"` (a
+     name should have been there and the bounded read failed) is a
+     different fact from `"unnamed"` (the descriptor positively records
+     none), and so is an unreadable **type** name. Folding either would
+     hide the one row that says something was lost, so only a row whose
+     type read cleanly **and** whose object name is positively absent is
+     ever a fold candidate.
+  2. **its type is on the retain list**: `Job`, `Process`, `Section`,
+     `Thread`, `Token`.
+- `object_name_status == "unnamed"` alone is therefore **not** the
+  suppression rule: rule 2 is what keeps an anonymous `Process`,
+  `Thread`, `Token`, `Section`, or `Job` handle — exactly the evidence a
+  cross-process access question turns on — visible however many of them
+  a dump carries.
+- The type list is a **retain** list, not an allow-to-fold list, and the
+  direction is normative. An allow list leaves every unlisted type
+  visible, so the default console still prints the wall of anonymous
+  rows this section exists to collapse, and it silently regresses with
+  every new Windows object type. The cost of the retain direction is
+  that an unclassified type is folded rather than shown; that cost is
+  bounded, because the fold line **names the type and its exact count**,
+  `summary.by_type` counts it, and `--verbose` prints it.
+- The fold line states the exact total, says **why** those rows folded
+  (no object name recorded), lists the per-type counts ordered by §1.5
+  (count descending, then type name ascending), and names `--verbose` as
+  the way to see them. Folding is deterministic, bounded,
   and linear in the record count: it is decided per record with no
   cross-row state.
 - The two null-name labels are explained inline whenever one of them is
@@ -3394,24 +3432,36 @@ excuses anything in §0–§8.
   `name_matched_candidate`, and per-field IAT nullability.
 - **rev6 (this revision)** — the recon console projection, from an
   investigator's report against the shipped v2.13 output
-  ([issue #98](https://github.com/bitbug0x55AA/dumpex/issues/98)). Four
+  ([issue #98](https://github.com/bitbug0x55AA/dumpex/issues/98)). Five
   presentation defects, no change to any record shape, coverage meaning,
   limitation code, diagnostic, ordering rule, or exit code:
 
   1. **`--handles --verbose` was silently ignored** — the CLI dispatch
      never forwarded the flag. Now wired end-to-end (§5.6.3).
   2. **A full anonymous handle inventory buried the useful rows.** §5.6.1
-     freezes a deterministic fold of approved low-context anonymous rows
-     into per-type counts, with the exact omitted count and a
-     `use --verbose to show all` hint. Folding is a projection: the
-     records, summary, `by_type`, coverage and exit code are identical
-     in both views, and `unnamed`/`unreadable` stay distinct — an
-     unreadable name is never folded.
-  3. **Real NT namespace names read as parser noise.** §5.6.2 adds
+     freezes a deterministic fold of anonymous rows into per-type counts,
+     with the exact omitted count and a `use --verbose to show all` hint.
+     Folding is a projection: the records, summary, `by_type`, coverage
+     and exit code are identical in both views, and `unnamed`/
+     `unreadable` stay distinct — an unreadable name is never folded.
+     The type list is a **retain** list (`Job`, `Process`, `Section`,
+     `Thread`, `Token`), not an allow-to-fold list: the first cut of this
+     used the allow direction, which left every unlisted type visible and
+     so still printed the wall of anonymous rows the fold exists to
+     collapse.
+  3. **The tables were separated but not aligned.** A per-column
+     minimum width is not truncation, so one long type, DLL or API name
+     pushed that one row's remaining columns right and left both tables
+     ragged under their own headers. §5.6 and §3.8.1 now size every
+     column to the widest value actually present, floored at the old
+     minimum and capped so an attacker-controlled name cannot set the
+     layout for every row. The shared rule is `column_width()` in
+     `dumpex/ui/console_layout.py`.
+  4. **Real NT namespace names read as parser noise.** §5.6.2 adds
      bounded, type-keyed notes (`\KnownDlls` and friends) that describe
      only what the descriptor recorded and never enumerate a directory's
      contents from the analysis host.
-  4. **The verbose process block spoke dumpex's internal vocabulary.**
+  5. **The verbose process block spoke dumpex's internal vocabulary.**
      §3.8.1 gives the import table headers and a legend for the
      `IAT Slot VA -> Resolved Target VA` pair (and surfaces
      `slot_in_bounds` as an observation with a footnote); §3.8.2 replaces

--- a/dumpex/commands/handles.py
+++ b/dumpex/commands/handles.py
@@ -28,10 +28,12 @@ through to it.
 Console verbosity is a PROJECTION and nothing else (#98): the
 CommandResult `collect_handles()` returns is byte-identical whatever
 `verbose` is, so `--json` always carries the complete normalized
-inventory. The default console folds the low-context anonymous rows
-listed in `_FOLDABLE_ANONYMOUS_TYPES` into per-type counts and says
-exactly how many it folded; `--verbose` renders every record. Nothing is
-ever removed from the records, the summary, or `by_type`.
+inventory. The default console folds anonymous rows -- every row whose
+descriptor records no object name, except the investigation-relevant
+types in `_RETAINED_ANONYMOUS_TYPES` and any row that LOST a name --
+into per-type counts, and says exactly how many it folded; `--verbose`
+renders every record. Nothing is ever removed from the records, the
+summary, or `by_type`.
 """
 from minidump.constants import MINIDUMP_STREAM_TYPE
 from minidump.minidumpfile import MinidumpFile
@@ -46,6 +48,7 @@ from dumpex.output.records import (
     HandleRecord, handle_name_display, hex_address,
 )
 from dumpex.ui.colors import BOLD, DIM, YELLOW, console_safe
+from dumpex.ui.console_layout import column_width
 
 
 _HANDLE_STREAM = MINIDUMP_STREAM_TYPE.HandleDataStream
@@ -411,8 +414,9 @@ def _access_display(record: HandleRecord) -> str:
 
     When §5.2's deferred type-specific decoding lands and this starts
     returning names like "FILE_ALL_ACCESS", the table's column widths do
-    NOT need revisiting: every column is followed by two literal spaces,
-    and tests/unit/test_handles_cmd.py::
+    NOT need revisiting: the Access column is measured from the values
+    this function actually returns (see _column_width), and
+    tests/unit/test_handles_cmd.py::
     test_no_column_fuses_into_the_next_however_wide_its_value already
     parametrizes this function's output over decoded-width strings to
     keep that true."""
@@ -425,63 +429,70 @@ def _count_display(value) -> str:
     return "?" if value is None else str(value)
 
 
-# Every column in §5.6's table is followed by two LITERAL spaces, so a
-# value that outgrows its column pushes the rest of the row right but
-# stays readable. A width alone does not do that: `{name:<16}` is a
-# MINIMUM width, not a truncation, so a 16-character type name left zero
-# separation and rendered as e.g. "ActivationObject0x00000002" -- one
-# unsplittable token in the exact place an analyst reads the granted-
-# access mask. Windows has many such types (WaitCompletionPacket,
-# FilterConnectionPort, DxgkSharedSyncObject, IoCompletionReserve, ...),
-# so that was ordinary output, not an edge case. Truncating a value would
-# destroy evidence; each column is narrowed by exactly its two spaces
-# instead, which keeps §5.6's sample rows byte-identical (their widest
-# values are "(unreadable)" and "0x0012019f") while making the separator
-# structural.
+# Every column in §5.6's table is followed by two LITERAL spaces, and
+# every column is sized to the WIDEST VALUE IT ACTUALLY HOLDS in this
+# render, floored at the minimum below and capped above.
 #
-# The Access column is included even though `_access_display()` cannot
-# exceed 10 characters today: §5.2 defers type-specific permission
-# decoding to a later feature, and a decoded "FILE_ALL_ACCESS" beside a
-# 3-digit handle count would otherwise reproduce the exact same fusion
-# one column over.
-_TYPE_COLUMN_WIDTH = 14
-_ACCESS_COLUMN_WIDTH = 10
+# See dumpex.ui.console_layout.column_width() for why a fixed width
+# separates a table without aligning it, and for what the cap protects
+# against. Windows carries plenty of 16-to-20-character type names
+# (WaitCompletionPacket, FilterConnectionPort, IoCompletionReserve, ...),
+# so a ragged Type column was ordinary output rather than an edge case.
+#
+# The minimums keep an ordinary table's shape stable across dumps -- a
+# dump whose type names are all short still renders at the familiar
+# width rather than collapsing. The caps sit far above any real Windows
+# object type name, so only a dump-crafted one ever reaches them.
+_TYPE_COLUMN_MIN_WIDTH = 14
+_TYPE_COLUMN_MAX_WIDTH = 40
+# _access_display() cannot exceed 10 characters today, but §5.2 defers
+# type-specific permission decoding to a later feature and a decoded
+# "FILE_ALL_ACCESS" would land here.
+_ACCESS_COLUMN_MIN_WIDTH = 10
+_ACCESS_COLUMN_MAX_WIDTH = 32
+# `Cnt`/`Ptr` are right-aligned uint32 counters -- 10 digits at the very
+# most, so they need no cap of their own.
+_COUNT_COLUMN_MIN_WIDTH = 3
+
+# A handle is always hex_address()'s fixed 18 characters (§1.3), so this
+# one is a constant rather than a measurement.
+_HANDLE_COLUMN_WIDTH = 18
 
 
-# ── #98: console folding, kept strictly a projection ────────────────────
-# The default console folds ONLY the anonymous rows of these types into
-# per-type counts. Two independent conditions have to hold before a row
-# is folded, and neither is sufficient alone:
+# ── #98: console folding, kept strictly a projection ────────────────
+# A real dump's handle table is dominated by rows whose Object column is
+# `(unnamed)`, and they bury the handles an investigation turns on. The
+# default console therefore folds an anonymous row into a per-type count
+# UNLESS one of two things holds:
 #
-#   1. `object_name_status == "unnamed"` -- the descriptor positively
-#      records no object name (§5.2.1). An "unreadable" name is EVIDENCE
-#      LOSS and is never folded: folding it would hide the one row an
-#      analyst needs to see to know something was lost.
-#   2. the captured type is on this explicitly approved list.
+#   1. the row lost evidence. `object_name_status == "unreadable"` (a
+#      name should have been there and the bounded read failed) is a
+#      different fact from `"unnamed"` (the descriptor positively records
+#      none) -- §5.2.1 -- and so is an unreadable TYPE name. Folding
+#      either would hide the one row that says something was lost, so
+#      only a row whose type read cleanly AND whose object name is
+#      positively absent is ever a fold candidate.
+#   2. the type is on the retain list below.
 #
-# Condition 2 exists because condition 1 alone is far too aggressive: an
-# anonymous Process, Thread, Token, Section, or Job handle is exactly the
-# kind of evidence a cross-process-access question turns on, and none of
-# those appear below. The list is an ALLOW list, so a type nobody has
-# considered (including a type name a dump invents) stays visible by
-# default -- the failure mode of a new Windows object type is a slightly
-# longer table, never a hidden handle.
+# Condition 2 is why `object_name_status == "unnamed"` is not the sole
+# suppression rule: an anonymous Process, Thread, Token, Section, or Job
+# handle is exactly the evidence a cross-process-access question turns
+# on. Those five stay visible however many of them a dump carries.
 #
-# Every type here is a synchronization/scheduling primitive whose
-# anonymous instances carry no name, no path, and no cross-process
-# reference: with no object name there is nothing left in the descriptor
-# to investigate beyond the per-type count the fold line prints.
-_FOLDABLE_ANONYMOUS_TYPES = frozenset({
-    "Event",
-    "EtwRegistration",
-    "IoCompletion",
-    "IoCompletionReserve",
-    "IRTimer",
-    "Mutant",
-    "Semaphore",
-    "Timer",
-    "TpWorkerFactory",
-    "WaitCompletionPacket",
+# This is a RETAIN list, not an allow-to-fold list. That direction is
+# deliberate and it is the opposite of the first cut of this feature: an
+# allow list left every unlisted type visible, so the default console
+# still printed the wall of anonymous rows it exists to collapse, and it
+# would have quietly regressed again with every new Windows object type.
+# The cost of the retain direction is that a new type is folded rather
+# than shown -- bounded, because the fold line names the type and its
+# exact count, `summary.by_type` counts it, and `--verbose` prints it.
+_RETAINED_ANONYMOUS_TYPES = frozenset({
+    "Job",
+    "Process",
+    "Section",
+    "Thread",
+    "Token",
 })
 
 # Frozen, per-name explanations for NT Object Manager names an analyst
@@ -542,10 +553,10 @@ def _is_foldable(record: HandleRecord) -> bool:
     deterministic and linear in the record count however the table is
     ordered. Both name statuses are read as themselves (never as bare
     truthiness of the name): "unnamed" and "unreadable" are different
-    facts (§5.2.1) and only the first is ever foldable."""
+    facts (§5.2.1) and only the first is ever a fold candidate."""
     return (record.object_name_status == "unnamed"
             and record.type_name_status == "ok"
-            and record.type_name in _FOLDABLE_ANONYMOUS_TYPES)
+            and record.type_name not in _RETAINED_ANONYMOUS_TYPES)
 
 
 def _partition_for_console(records, verbose: bool) -> "tuple[list, dict]":
@@ -639,19 +650,35 @@ def render_handles_console(records, coverage, *, verbose: bool = False) -> None:
     folded_total = sum(folded.values())
 
     if shown:
-        header = (f"{'Handle':<18}  {'Type':<{_TYPE_COLUMN_WIDTH}}  "
-                  f"{'Access':<{_ACCESS_COLUMN_WIDTH}}  {'Cnt':>3}  {'Ptr':>3}  Object")
+        # Cells are built once, up front, so the column widths below are
+        # measured on exactly the strings that get printed (escaped, and
+        # projected through handle_name_display()) rather than on the raw
+        # record values -- an escape expands a name, and a column sized
+        # on the unescaped value would be too narrow for its own row.
+        rows = [(record.handle,
+                 console_safe(handle_name_display(record.type_name, record.type_name_status)),
+                 _access_display(record),
+                 _count_display(record.handle_count),
+                 _count_display(record.pointer_count),
+                 console_safe(handle_name_display(record.object_name, record.object_name_status)))
+                for record in shown]
+        type_w = column_width("Type", [r[1] for r in rows],
+                                minimum=_TYPE_COLUMN_MIN_WIDTH, cap=_TYPE_COLUMN_MAX_WIDTH)
+        access_w = column_width("Access", [r[2] for r in rows],
+                                  minimum=_ACCESS_COLUMN_MIN_WIDTH, cap=_ACCESS_COLUMN_MAX_WIDTH)
+        cnt_w = column_width("Cnt", [r[3] for r in rows], minimum=_COUNT_COLUMN_MIN_WIDTH)
+        ptr_w = column_width("Ptr", [r[4] for r in rows], minimum=_COUNT_COLUMN_MIN_WIDTH)
+
+        # `Object` is the last column and is never padded: padding a
+        # trailing column only adds invisible trailing whitespace.
+        header = (f"{'Handle':<{_HANDLE_COLUMN_WIDTH}}  {'Type':<{type_w}}  "
+                  f"{'Access':<{access_w}}  {'Cnt':>{cnt_w}}  {'Ptr':>{ptr_w}}  Object")
         print()
         print(f"  {DIM(header)}")
-        for record in shown:
-            type_display = console_safe(
-                handle_name_display(record.type_name, record.type_name_status))
-            object_display = console_safe(
-                handle_name_display(record.object_name, record.object_name_status))
-            print(f"  {record.handle:<18}  {type_display:<{_TYPE_COLUMN_WIDTH}}  "
-                  f"{_access_display(record):<{_ACCESS_COLUMN_WIDTH}}  "
-                  f"{_count_display(record.handle_count):>3}  "
-                  f"{_count_display(record.pointer_count):>3}  {object_display}")
+        for handle, type_display, access, count, pointers, object_display in rows:
+            print(f"  {handle:<{_HANDLE_COLUMN_WIDTH}}  {type_display:<{type_w}}  "
+                  f"{access:<{access_w}}  {count:>{cnt_w}}  {pointers:>{ptr_w}}  "
+                  f"{object_display}")
 
     # The two null-name labels are dumpex's own vocabulary and mean two
     # different things (§5.2.1); printed only when one of them is
@@ -669,8 +696,8 @@ def render_handles_console(records, coverage, *, verbose: bool = False) -> None:
     if folded_total:
         listed = ", ".join(f"{console_safe(name)} {count}" for name, count in folded.items())
         print()
-        print(f"  {folded_total} anonymous handle(s) of routine low-context type(s) "
-              f"not shown: {listed}")
+        print(f"  {folded_total} anonymous handle(s) not shown "
+              f"(no object name recorded): {listed}")
         print(f"  {DIM(_FOLD_HINT)}")
 
     notes = _namespace_notes(records)

--- a/dumpex/commands/process.py
+++ b/dumpex/commands/process.py
@@ -42,6 +42,7 @@ from dumpex.output.records import (
     ProcessRecord, IatRecord, ImportEntryRecord, ProcessDiagnosticRecord, hex_address,
 )
 from dumpex.ui.colors import BOLD, console_safe
+from dumpex.ui.console_layout import column_width
 
 
 # ── §3.5.4/§6.1 -- IAT diagnostic `details` keys that carry addresses ────
@@ -535,9 +536,21 @@ def render_process_console(record: ProcessRecord, coverage, *, verbose: bool = F
 # does it point"). The headers and the one legend line below are the
 # whole fix; no new evidence is read, and the v2.13 record shape is
 # untouched.
-_IAT_DLL_COLUMN_WIDTH = 24
-_IAT_SYMBOL_COLUMN_WIDTH = 28
-_IAT_ADDRESS_COLUMN_WIDTH = 20
+# Sized to the widest value each column actually holds in this render,
+# floored at the minimum and capped above -- the same
+# dumpex.ui.console_layout.column_width() rule the --handles table uses,
+# for the same reason: a fixed minimum is not truncation, so one long DLL
+# or API name shifted that ONE row's remaining columns right and left the
+# table ragged below its own header. `dll` and `symbol` come out of the
+# dumped image and are attacker-controlled, so the caps stop one hostile
+# name from padding every row.
+_IAT_DLL_COLUMN_MIN_WIDTH = 24
+_IAT_DLL_COLUMN_MAX_WIDTH = 48
+_IAT_SYMBOL_COLUMN_MIN_WIDTH = 28
+_IAT_SYMBOL_COLUMN_MAX_WIDTH = 64
+# Slot/target are hex_address()'s fixed 18 characters (§1.3) or
+# "(unknown)"; the header itself is the widest thing in the column.
+_IAT_ADDRESS_COLUMN_MIN_WIDTH = 20
 
 # Pre-wrapped rather than wrapped at print time: dumpex's own text, at a
 # fixed width, so the block is byte-identical on every terminal.
@@ -553,9 +566,10 @@ _IAT_LEGEND_LINES = (
 # claim about hooking -- a target inside another module is ordinary for
 # forwarded exports and API-set resolution.
 _IAT_OUT_OF_BOUNDS_MARKER = " *"
-_IAT_OUT_OF_BOUNDS_NOTE = ("* the IAT slot lies outside the recorded import directory "
-                           "bounds -- an observation about this dump's directory "
-                           "framing, not a verdict about the import")
+_IAT_OUT_OF_BOUNDS_NOTE_LINES = (
+    "* the IAT slot lies outside the recorded import directory bounds -- an",
+    "  observation about this dump's directory framing, not a verdict about the import",
+)
 
 
 def _import_symbol_text(entry: ImportEntryRecord) -> str:
@@ -580,22 +594,35 @@ def _render_iat_entries(entries) -> None:
     for line in _IAT_LEGEND_LINES:
         print(f"    {line}")
     print()
-    header = (f"{'DLL':<{_IAT_DLL_COLUMN_WIDTH}}  {'Imported API':<{_IAT_SYMBOL_COLUMN_WIDTH}}  "
-              f"{'IAT Slot VA':<{_IAT_ADDRESS_COLUMN_WIDTH}}  Resolved Target VA")
-    print(f"    {header}")
-    any_out_of_bounds = False
-    for e in entries:
-        dll_text = console_safe(e.dll) or "(unknown)"
-        symbol_text = console_safe(_import_symbol_text(e))
-        marker = ""
-        if e.slot_in_bounds is False:
-            marker = _IAT_OUT_OF_BOUNDS_MARKER
-            any_out_of_bounds = True
-        print(f"    {dll_text:<{_IAT_DLL_COLUMN_WIDTH}}  {symbol_text:<{_IAT_SYMBOL_COLUMN_WIDTH}}  "
-              f"{(e.iat_slot_va or '(unknown)'):<{_IAT_ADDRESS_COLUMN_WIDTH}}  "
-              f"{e.resolved_target_va or '(unknown)'}{marker}")
-    if any_out_of_bounds:
-        print(f"    {_IAT_OUT_OF_BOUNDS_NOTE}")
+
+    # Cells first, widths second, printing third -- the widths are
+    # measured on the ESCAPED strings that actually reach the terminal,
+    # since console_safe() can expand a name past its raw length.
+    rows = [(console_safe(e.dll) or "(unknown)",
+             console_safe(_import_symbol_text(e)),
+             e.iat_slot_va or "(unknown)",
+             e.resolved_target_va or "(unknown)",
+             _IAT_OUT_OF_BOUNDS_MARKER if e.slot_in_bounds is False else "")
+            for e in entries]
+    dll_w = column_width("DLL", [r[0] for r in rows],
+                           minimum=_IAT_DLL_COLUMN_MIN_WIDTH, cap=_IAT_DLL_COLUMN_MAX_WIDTH)
+    symbol_w = column_width("Imported API", [r[1] for r in rows],
+                              minimum=_IAT_SYMBOL_COLUMN_MIN_WIDTH,
+                              cap=_IAT_SYMBOL_COLUMN_MAX_WIDTH)
+    slot_w = column_width("IAT Slot VA", [r[2] for r in rows],
+                            minimum=_IAT_ADDRESS_COLUMN_MIN_WIDTH)
+
+    # `Resolved Target VA` is the last column and is never padded --
+    # padding it would only add invisible trailing whitespace (and would
+    # separate the out-of-bounds marker from the value it marks).
+    print(f"    {'DLL':<{dll_w}}  {'Imported API':<{symbol_w}}  "
+          f"{'IAT Slot VA':<{slot_w}}  Resolved Target VA")
+    for dll_text, symbol_text, slot_va, target_va, marker in rows:
+        print(f"    {dll_text:<{dll_w}}  {symbol_text:<{symbol_w}}  "
+              f"{slot_va:<{slot_w}}  {target_va}{marker}")
+    if any(row[4] for row in rows):
+        for line in _IAT_OUT_OF_BOUNDS_NOTE_LINES:
+            print(f"    {line}")
 
 
 # ── #98: Identity Verification (was "Evidence Matrix") ──────────────────

--- a/dumpex/hunt/_console.py
+++ b/dumpex/hunt/_console.py
@@ -14,9 +14,14 @@ directly; nothing here is deprecated for existing callers.
 from dumpex.ui.console_layout import (   # noqa: F401
     MIN_WIDTH, MAX_WIDTH, FALLBACK_WIDTH,
     strip_ansi, visible_len, resolve_width, wrap_text, render_kv_block,
+    column_width,
 )
 
+# Mirrors dumpex.ui.console_layout.__all__ exactly -- a name added there
+# and not here makes this shim a partial view of the module it claims to
+# re-export, which tests/hunt/test_console_layout_shim.py rejects.
 __all__ = [
     "MIN_WIDTH", "MAX_WIDTH", "FALLBACK_WIDTH",
     "strip_ansi", "visible_len", "resolve_width", "wrap_text", "render_kv_block",
+    "column_width",
 ]

--- a/dumpex/ui/console_layout.py
+++ b/dumpex/ui/console_layout.py
@@ -23,6 +23,7 @@ import sys
 __all__ = [
     "MIN_WIDTH", "MAX_WIDTH", "FALLBACK_WIDTH",
     "strip_ansi", "visible_len", "resolve_width", "wrap_text", "render_kv_block",
+    "column_width",
 ]
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
@@ -117,3 +118,34 @@ def render_kv_block(pairs: list, indent: int = 2, label_width: "int | None" = No
         label_width = max((len(k) for k, _ in pairs), default=0)
     pad = " " * indent
     return [f"{pad}{label:<{label_width}}  {value}" for label, value in pairs]
+
+
+def column_width(header: str, cells, *, minimum: int = 0, cap: "int | None" = None) -> int:
+    """The width that lets every cell in ONE render of a table sit in its
+    own column: the widest value present, floored by the header text and
+    by `minimum`, and capped by `cap`.
+
+    Tables built from a fixed per-column width are not aligned, they are
+    merely separated. A width in a format spec (`{value:<14}`) is a
+    MINIMUM, never a truncation, so a single over-wide cell pushes the
+    rest of ITS OWN row right while every other row stays put -- the
+    table reads as ragged below its own header, and a column-wise read
+    (or `awk`, or a copy-paste into a report) is worthless. Sizing to the
+    data instead lines every row up with every other row and with the
+    header, without ever dropping a character.
+
+    `cap` is the safety valve for columns fed by dump-derived text, which
+    is attacker-controlled: without a ceiling, one 4,000-character name
+    would pad EVERY row to 4,000 columns and destroy the table for all
+    the other records. A cell wider than `cap` is still printed in full
+    -- its own row simply overflows and pushes right, which is the
+    ordinary fixed-width behaviour, now confined to the pathological case
+    instead of being the normal one.
+
+    Measured with visible_len(), so a cell that already carries ANSI
+    styling is sized by what it occupies on screen rather than by its
+    escape sequences. Linear in the number of cells, with no state
+    carried between renders."""
+    widest = max((visible_len(cell) for cell in cells), default=0)
+    width = max(minimum, visible_len(header), widest)
+    return width if cap is None else min(width, cap)

--- a/tests/unit/test_handles_cmd.py
+++ b/tests/unit/test_handles_cmd.py
@@ -726,7 +726,11 @@ def test_the_console_table_and_the_summary_project_names_the_same_way():
         {"handle": 0x10, "type_name": "(unnamed)", "object_name": None},
         {"handle": 0x20, "type_name": None, "object_name": None},
     ]))
-    rows = [l for l in _console(result).splitlines() if "0x00000000000000" in l]
+    # Rendered verbose: both rows are anonymous, so the DEFAULT console
+    # folds one of them (#98). The claim under test is that the Type
+    # column and by_type project a name the same way, which is a property
+    # of the projection, not of which rows a view chose to print.
+    rows = [l for l in _console(result, verbose=True).splitlines() if "0x00000000000000" in l]
     types = [l.split("  ")[2].strip() for l in rows]
 
     assert types[0] != types[1]                       # the two rows are distinguishable
@@ -764,7 +768,9 @@ def test_a_name_already_carrying_the_suffix_stays_distinct_everywhere():
         {"handle": 0x20, "type_name": "(unnamed) [captured name]", "object_name": None},
     ]))
 
-    rows = [l for l in _console(result).splitlines() if "0x00000000000000" in l]
+    # Verbose for the same reason as the case above: both rows are
+    # anonymous and the default view folds them.
+    rows = [l for l in _console(result, verbose=True).splitlines() if "0x00000000000000" in l]
     types = [l.split("  ")[2].strip() for l in rows]
     assert types[0] != types[1]
     assert set(types) == set(result.summary["by_type"])
@@ -787,7 +793,12 @@ def test_console_table_prints_each_null_name_by_its_own_status():
         {"handle": 0x23C, "type_name": BAD_RVA, "object_name": BAD_RVA,
          "granted_access": 1, "handle_count": 1, "pointer_count": 2},
     ]))
-    text = _console(result)
+    # Verbose: the anonymous Key row is folded out of the default view
+    # (#98), and this case is about how each null name PRINTS, not about
+    # which rows a view selects. The widths are unchanged either way --
+    # "(unreadable)" (12) is still narrower than the Type column's
+    # minimum, so §5.6's sample rows stay byte-identical.
+    text = _console(result, verbose=True)
 
     assert "0x0000000000000234  File            0x0012019f    1   32  \\Device\\NamedPipe\\mypipe" in text
     assert "0x0000000000000238  Key             0x00020019    1    3  (unnamed)" in text
@@ -1063,8 +1074,9 @@ def test_collect_handles_never_routes_through_the_narrow_get_handles_view(monkey
 # side: the records, the summary and by_type are what collect_handles()
 # produced, whatever the console chose to print.
 
-# One anonymous handle of each foldable type, plus the investigation-
-# relevant anonymous types that must survive folding, plus a named row.
+# Anonymous rows of two ordinary types (folded), the five
+# investigation-relevant types that must survive folding whatever their
+# count, and one named row.
 _FOLDING_FIXTURE = (
     [{"handle": 0x10 + i, "type_name": "Event", "object_name": None} for i in range(5)]
     + [{"handle": 0x30 + i, "type_name": "Mutant", "object_name": None} for i in range(2)]
@@ -1077,12 +1089,12 @@ _FOLDING_FIXTURE = (
 )
 
 
-def test_default_console_folds_only_approved_low_context_anonymous_rows():
+def test_default_console_folds_anonymous_rows_but_retains_the_approved_types():
     result = collect_handles(_mf_with(_FOLDING_FIXTURE))
     text = _console(result)
     shown = "\n".join(_rows(text))
 
-    # Folded: anonymous Event/Mutant.
+    # Folded: anonymous rows of any type not on the retain list.
     assert "Event" not in shown and "Mutant" not in shown
     # Never folded: the anonymous types an investigation turns on.
     for kept in ("Process", "Thread", "Token", "Section", "Job"):
@@ -1094,7 +1106,7 @@ def test_default_console_reports_the_exact_folded_count_per_type():
     text = _console(collect_handles(_mf_with(_FOLDING_FIXTURE)))
     line = next(l for l in text.splitlines() if "not shown" in l)
 
-    assert "7 anonymous handle(s)" in line       # 5 Event + 2 Mutant
+    assert "7 anonymous handle(s) not shown" in line   # 5 Event + 2 Mutant
     assert "Event 5" in line and "Mutant 2" in line
     assert "use --verbose to show all" in text
 
@@ -1108,7 +1120,7 @@ def test_folded_counts_are_ordered_count_desc_then_name_asc():
         + [{"handle": 0x80, "type_name": "Semaphore", "object_name": None}])
     line = next(l for l in _console(collect_handles(_mf_with(descriptors))).splitlines()
                 if "not shown" in l)
-    listed = line.split("not shown:")[1]
+    listed = line.split("recorded):")[1]
 
     assert listed.index("Event 3") < listed.index("Mutant 3") < listed.index("Semaphore 1")
 
@@ -1171,23 +1183,53 @@ def test_a_named_handle_of_a_foldable_type_is_never_folded():
     assert "0x0000000000000020" not in shown
 
 
-def test_an_unknown_type_stays_visible_by_default():
-    """The fold list is an ALLOW list: a type nobody has classified --
-    including one a dump invents -- must default to being shown."""
+def test_an_unclassified_anonymous_type_is_folded_but_never_lost():
+    """The type list is a RETAIN list, so an unclassified type -- a new
+    Windows object type, or one a dump invents -- folds like any other
+    anonymous row. It must still be NAMED and COUNTED, in the fold line
+    and in by_type, and reachable with --verbose."""
     result = collect_handles(_mf_with([
         {"handle": 0x10, "type_name": "SomeFutureObjectType", "object_name": None},
     ]))
-    assert "SomeFutureObjectType" in _console(result)
+    text = _console(result)
+
+    assert _rows(text) == []                                  # folded out of the table
+    assert "1 anonymous handle(s) not shown" in text
+    assert "SomeFutureObjectType 1" in text                   # named and counted
+    assert result.summary["by_type"] == {"SomeFutureObjectType": 1}
+    assert len(_rows(_console(result, verbose=True))) == 1     # reachable
+
+
+@pytest.mark.parametrize("type_name", ["Process", "Thread", "Token", "Section", "Job"])
+def test_the_retained_anonymous_types_are_never_folded(type_name):
+    """#98 forbids `object_name_status == "unnamed"` as the SOLE
+    suppression rule: an anonymous handle to one of these five is exactly
+    the evidence a cross-process-access question turns on."""
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": type_name, "object_name": None},
+    ]))
+    text = _console(result)
+    assert len(_rows(text)) == 1
+    assert "not shown" not in text
 
 
 def test_nothing_is_folded_when_no_row_qualifies():
-    result = collect_handles(_mf_with(_POPULATED))
-    assert "not shown" not in _console(result)
+    """Every row carries a captured object name, so none is a fold
+    candidate and the fold line must not appear at all."""
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": "File", "object_name": "\\Device\\X"},
+        {"handle": 0x20, "type_name": "Event", "object_name": "\\BaseNamedObjects\\e"},
+    ]))
+    text = _console(result)
+    assert "not shown" not in text
+    assert len(_rows(text)) == 2
 
 
 def test_the_name_status_legend_explains_unnamed_versus_unreadable():
+    # A retained type, so the row survives the default projection and the
+    # legend describes a label that is actually on screen.
     result = collect_handles(_mf_with([
-        {"handle": 0x10, "type_name": "Key", "object_name": None},
+        {"handle": 0x10, "type_name": "Token", "object_name": None},
     ]))
     text = _console(result)
     assert "(unnamed) = the descriptor records no name" in text
@@ -1252,12 +1294,16 @@ def test_a_note_survives_its_row_being_folded():
     text = _console(result)
     assert "NT Object Manager directory" in text
 
-    original = handles_module._FOLDABLE_ANONYMOUS_TYPES
+    # Forced through the predicate rather than through the type list, so
+    # the case keeps holding whatever the fold RULE becomes.
+    original = handles_module._is_foldable
     try:
-        handles_module._FOLDABLE_ANONYMOUS_TYPES = frozenset(original | {"Directory"})
-        assert "NT Object Manager directory" in _console(result)
+        handles_module._is_foldable = lambda record: True
+        folded_text = _console(result)
+        assert _rows(folded_text) == []                    # the row is gone ...
+        assert "NT Object Manager directory" in folded_text  # ... the note is not
     finally:
-        handles_module._FOLDABLE_ANONYMOUS_TYPES = original
+        handles_module._is_foldable = original
 
 
 def test_the_notes_block_escapes_its_own_labels():
@@ -1298,3 +1344,116 @@ def test_cmd_handles_forwards_verbose_to_the_renderer_only():
     assert default_result.summary == verbose_result.summary
     assert default_result.coverage.status == verbose_result.coverage.status
     assert len(_rows(verbose_buf.getvalue())) > len(_rows(default_buf.getvalue()))
+
+
+def _table_block(text: str) -> list:
+    """The header line plus every row, as printed."""
+    lines = text.splitlines()
+    header_index = next(i for i, l in enumerate(lines)
+                        if "Handle" in l and "Access" in l and "Object" in l)
+    return [lines[header_index]] + _rows(text)
+
+
+# The table's left-aligned columns, and the right-aligned counters. A
+# left-aligned column is aligned when every row's value STARTS at the
+# header label's own offset; a right-aligned one when every row's value
+# ENDS at the header label's end. Checked against the header rather than
+# row-against-row, so a table that is internally consistent but shifted
+# out from under its own header still fails.
+_LEFT_ALIGNED_COLUMNS = ("Type", "Access", "Object")
+_RIGHT_ALIGNED_COLUMNS = ("Cnt", "Ptr")
+
+
+def _assert_columns_line_up(text: str) -> list:
+    block = _table_block(text)
+    header = block[0]
+    for row in block[1:]:
+        for label in _LEFT_ALIGNED_COLUMNS:
+            at = header.index(label)
+            assert row[at] != " " and row[at - 1] == " ", (
+                f"{label!r} does not start at column {at} in {row!r}")
+        for label in _RIGHT_ALIGNED_COLUMNS:
+            end = header.index(label) + len(label)
+            assert row[end - 1] != " " and row[end] == " ", (
+                f"{label!r} does not end at column {end} in {row!r}")
+    return block
+
+
+def test_every_row_lines_its_columns_up_with_the_header():
+    """A per-column MINIMUM width separates a table without aligning it:
+    one 20-character type name used to push that ONE row's Access/Cnt/
+    Ptr/Object right while every other row stayed put, leaving the table
+    ragged under its own header. Columns are now sized to the widest
+    value actually present, so every row lines up with the header and
+    with every other row."""
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": "File", "object_name": "A", "granted_access": 1},
+        # Real Windows type names, far wider than the column minimum.
+        {"handle": 0x20, "type_name": "WaitCompletionPacket", "object_name": "B",
+         "granted_access": 0x0012019F, "handle_count": 100, "pointer_count": 999},
+        {"handle": 0x30, "type_name": "IoCompletionReserve", "object_name": "C",
+         "granted_access": 2},
+    ]))
+    assert len(_assert_columns_line_up(_console(result))) == 4
+
+
+def test_a_short_table_still_lines_up():
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": "File", "object_name": "\\Device\\X"},
+        {"handle": 0x20, "type_name": "Key", "object_name": BAD_RVA},
+    ]))
+    _assert_columns_line_up(_console(result))
+
+
+def test_the_widest_value_sets_the_column_for_every_row():
+    """The same record renders wider once a wider type shares the table
+    -- the column grows, the value does not change."""
+    narrow = _console(collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": "File", "object_name": "A"}])))
+    wide = _console(collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": "File", "object_name": "A"},
+        {"handle": 0x20, "type_name": "WaitCompletionPacket", "object_name": "B"}])))
+
+    narrow_header = _table_block(narrow)[0]
+    wide_header = _table_block(wide)[0]
+    assert wide_header.index("Access") > narrow_header.index("Access")
+    # ... and the File row still reads exactly the same value.
+    assert _rows(narrow)[0].split()[1] == _rows(wide)[0].split()[1] == "File"
+    _assert_columns_line_up(wide)
+
+
+def test_a_hostile_type_name_cannot_set_the_layout_for_every_row():
+    """Type names are attacker-controlled. Without a ceiling, one absurd
+    name would pad EVERY row to its width and destroy the table for the
+    other handles -- so the column stops growing at the cap and only that
+    row overflows. Nothing is truncated."""
+    import dumpex.commands.handles as handles_module
+    over_cap = "T" * (handles_module._TYPE_COLUMN_MAX_WIDTH * 2)
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": "File", "object_name": "A"},
+        {"handle": 0x20, "type_name": over_cap, "object_name": "B"},
+    ]))
+    text = _console(result)
+
+    assert over_cap in text          # the value itself is never truncated
+    ordinary = next(l for l in _rows(text) if " File " in l)
+    hostile = next(l for l in _rows(text) if over_cap in l)
+    # The ordinary row is unaffected by its neighbour ...
+    assert len(ordinary) < handles_module._TYPE_COLUMN_MAX_WIDTH + 60
+    # ... both rows still start the Type column together ...
+    assert hostile.index(over_cap) == ordinary.index("File")
+    # ... and only the over-cap row runs past it.
+    assert len(hostile) > len(ordinary)
+
+
+def test_column_widths_are_measured_on_the_escaped_text():
+    """console_safe() EXPANDS a name (one control character becomes four
+    visible characters), so a column sized on the raw value would be too
+    narrow for its own row."""
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": "A\x1bB", "object_name": "X", "granted_access": 1},
+        {"handle": 0x20, "type_name": "File", "object_name": "Y", "granted_access": 2},
+    ]))
+    text = _console(result)
+    assert "\\x1b" in text
+    _assert_columns_line_up(text)

--- a/tests/unit/test_process_cmd.py
+++ b/tests/unit/test_process_cmd.py
@@ -1601,6 +1601,108 @@ def test_verbose_iat_row_keeps_the_slot_and_target_in_their_own_columns():
     assert f"{entry.iat_slot_va}{entry.resolved_target_va}" not in row
 
 
+def _iat_block(text: str) -> list:
+    """The import table's header line plus its rows."""
+    lines = text.splitlines()
+    header_index = next(i for i, l in enumerate(lines)
+                        if "DLL" in l and "IAT Slot VA" in l)
+    header = lines[header_index]
+    rows = []
+    for line in lines[header_index + 1:]:
+        if not line.strip() or line.strip().startswith("*"):
+            break
+        rows.append(line)
+    return [header] + rows
+
+
+def _assert_iat_columns_line_up(text: str) -> list:
+    """Every column is left-aligned here, so each row's value must START
+    at its header label's own offset. Checked against the header, so a
+    table that is internally consistent but shifted out from under its
+    own header still fails."""
+    block = _iat_block(text)
+    header = block[0]
+    for row in block[1:]:
+        for label in ("DLL", "Imported API", "IAT Slot VA", "Resolved Target VA"):
+            at = header.index(label)
+            assert row[at] != " " and row[at - 1] == " ", (
+                f"{label!r} does not start at column {at} in {row!r}")
+    return block
+
+
+def test_verbose_iat_rows_line_their_columns_up_with_the_header():
+    """A fixed minimum column width separates the table without aligning
+    it: one long DLL or API name shifted that row's remaining columns
+    right while every other row stayed put."""
+    entries = [
+        records_module.ImportEntryRecord(
+            dll="KERNEL32.dll", import_by="name", symbol="CreateFileW", ordinal=None,
+            iat_slot_va="0x00007ff600021018", resolved_target_va="0x00007ffb12345678",
+            slot_in_bounds=True),
+        # A real API-set DLL name, far wider than the column minimum.
+        records_module.ImportEntryRecord(
+            dll="api-ms-win-core-synch-l1-2-0.dll", import_by="name",
+            symbol="WaitOnAddress", ordinal=None,
+            iat_slot_va="0x00007ff600021020", resolved_target_va="0x00007ffb12345690",
+            slot_in_bounds=True),
+        records_module.ImportEntryRecord(
+            dll="ADVAPI32.dll", import_by="ordinal", symbol=None, ordinal=12,
+            iat_slot_va="0x00007ff600021028", resolved_target_va="0x00007ffb123456a0",
+            slot_in_bounds=True),
+        records_module.ImportEntryRecord(
+            dll=None, import_by="unavailable", symbol=None, ordinal=None,
+            iat_slot_va="0x00007ff600021030", resolved_target_va=None,
+            slot_in_bounds=None),
+    ]
+    out = _rendered_record(_process_record_with_entries(entries), verbose=True)
+    assert len(_assert_iat_columns_line_up(out)) == 5
+
+
+def test_verbose_iat_column_grows_with_its_widest_value():
+    short = _rendered_record(_process_record_with_entries([
+        records_module.ImportEntryRecord(
+            dll="KERNEL32.dll", import_by="name", symbol="CreateFileW", ordinal=None,
+            iat_slot_va="0x00007ff600021018", resolved_target_va="0x00007ffb12345678",
+            slot_in_bounds=True)]), verbose=True)
+    long = _rendered_record(_process_record_with_entries([
+        records_module.ImportEntryRecord(
+            dll="KERNEL32.dll", import_by="name", symbol="CreateFileW", ordinal=None,
+            iat_slot_va="0x00007ff600021018", resolved_target_va="0x00007ffb12345678",
+            slot_in_bounds=True),
+        records_module.ImportEntryRecord(
+            dll="api-ms-win-core-synch-l1-2-0.dll", import_by="name",
+            symbol="WaitOnAddress", ordinal=None,
+            iat_slot_va="0x00007ff600021020", resolved_target_va="0x00007ffb12345690",
+            slot_in_bounds=True)]), verbose=True)
+
+    assert _iat_block(long)[0].index("Imported API") > _iat_block(short)[0].index("Imported API")
+    _assert_iat_columns_line_up(long)
+
+
+def test_a_hostile_dll_name_cannot_set_the_iat_layout_for_every_row():
+    """`dll`/`symbol` come out of the dumped image. The cap stops one
+    absurd name from padding every row; that row overflows instead, and
+    nothing is truncated."""
+    import dumpex.commands.process as process_module
+    over_cap = "D" * (process_module._IAT_DLL_COLUMN_MAX_WIDTH * 2)
+    out = _rendered_record(_process_record_with_entries([
+        records_module.ImportEntryRecord(
+            dll="KERNEL32.dll", import_by="name", symbol="CreateFileW", ordinal=None,
+            iat_slot_va="0x00007ff600021018", resolved_target_va="0x00007ffb12345678",
+            slot_in_bounds=True),
+        records_module.ImportEntryRecord(
+            dll=over_cap, import_by="name", symbol="Evil", ordinal=None,
+            iat_slot_va="0x00007ff600021020", resolved_target_va="0x00007ffb12345690",
+            slot_in_bounds=True)]), verbose=True)
+
+    assert over_cap in out                       # never truncated
+    rows = _iat_block(out)[1:]
+    ordinary = next(l for l in rows if "KERNEL32" in l)
+    hostile = next(l for l in rows if over_cap in l)
+    assert len(ordinary) < process_module._IAT_DLL_COLUMN_MAX_WIDTH + 80
+    assert hostile.index(over_cap) == ordinary.index("KERNEL32.dll")
+
+
 def test_verbose_iat_marks_an_out_of_bounds_slot_without_calling_it_a_verdict():
     """`slot_in_bounds is False` is an observation (§3.5.5 files it as a
     diagnostic, never a limitation). It must be visible in the table, and


### PR DESCRIPTION
Follow-up to #99, which shipped issue #98's console work with two defects found on real output. Still console-presentation only: no record shape, coverage meaning, limitation code, diagnostic, ordering rule or exit code changed, and v2.13's JSON stays byte-identical.

## 1. The handle fold ran the wrong way round

It used an **allow** list of low-context types, so every unlisted type stayed visible and a real dump's default `--handles` still printed the wall of anonymous rows the fold exists to collapse.

The type list is now a **retain** list. Every row whose descriptor positively records no object name folds, except:

- rows of `Job` / `Process` / `Section` / `Thread` / `Token` — the cross-process-access evidence #98 requires to stay visible, however many a dump carries;
- any row whose type or object name could not be **read**. That is evidence loss, and hiding it would hide the one row saying something was lost.

An unclassified type now folds rather than showing, which is bounded: the fold line names the type and its exact count, `summary.by_type` counts it, and `--verbose` prints it.

```text
  12 anonymous handle(s) not shown (no object name recorded): Event 9, Semaphore 3
  These rows are captured evidence and are complete in structured output -- use --verbose to show all.
```

## 2. Both console tables were separated but not aligned

A per-column width in a format spec is a **minimum**, not a truncation, so one 20-character type name (`WaitCompletionPacket`, `IoCompletionReserve`, …) or one long API-set DLL name pushed that **one** row's remaining columns right while every other row stayed put. The table read as ragged under its own header, and a column-wise read (or `awk`, or a copy-paste into a report) was worthless.

Every column in the `--handles` table and in the verbose `--process` import table is now sized to the widest value it actually holds in that render, floored at the previous minimum and capped above:

```text
  Handle              Type                  Access      Cnt  Ptr  Object
  0x0000000000000234  File                  0x0012019f    1   32  \Device\NamedPipe\mypipe
  0x0000000000000238  WaitCompletionPacket  0x00000001    1    1  X
  0x0000000000000240  Token                 0x00000008  100  999  (unnamed)
```

Widths are measured on the **escaped, projected** strings that are really printed — `console_safe()` expands a name, so a column sized on the raw record value would be too narrow for its own row. The caps exist because type, object, DLL and API names are attacker-controlled: without a ceiling one 4,000-character name would pad **every** row to 4,000 columns and destroy the table for the other records. An over-cap value is still printed in full; only its own row overflows.

The single width rule is `column_width()` in `dumpex/ui/console_layout.py`, shared by both tables so they cannot drift apart, and mirrored in `dumpex.hunt._console`'s re-export shim.

## On `--handles --verbose`

Already wired end-to-end in #99 (`dumpex/cli.py` → `cmd_handles(mf, verbose=...)`); the round-trip test covering it shows the folded rows under `--verbose` and identical JSON either way.

## Docs

Contract doc rev6 updated in place: §5.6 freezes measured column widths instead of fixed minimums, §5.6.1 freezes the retain direction and says why the allow direction fails, §3.8.1 points the import table at the same rule, and Appendix A's rev6 entry records both defects. CLI reference, SOC quickstart and CHANGELOG follow.

## Tests

`5253 passed, 1 skipped` (the skip is the real-dump corpus, unconfigured here). New coverage pins the fold direction (each retained type parametrized; an unclassified type folds but stays named and counted) and asserts alignment against the **header offsets** rather than against a format string — left-aligned columns must start at their header label's offset, right-aligned counters must end at its end — plus the cap behaviour and the escaped-width measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
