### PR TITLE
fix(recon): fold anonymous handles that have no type name either (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ counted in the headline and the `By type:` line, still in `summary`, and
 still in `--json`, and the fold line always names each type and its exact
 count, so nothing disappears unnamed.
 
+Only the **object** name decides whether a row is anonymous, so a handle
+with a captured object name is never folded whatever its type says — and
+a handle whose descriptor recorded no type name either (some dump writers
+record none for any handle) folds like any other anonymous row.
+
 Two kinds of row never fold. Anonymous `Process`, `Thread`, `Token`,
 `Section` and `Job` handles stay visible however many a dump carries —
 an anonymous handle to one of those is exactly the evidence a

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -179,11 +179,16 @@ name the descriptor positively records as absent — into per-type counts:
 Those rows are still captured, still counted in the headline and the
 `By type:` line, and still in `--json`. `--verbose` prints all of them.
 
+Only the **object** name decides whether a row is anonymous, so a handle
+with a captured object name is never folded whatever its type says.
+
 Anonymous `Process`, `Thread`, `Token`, `Section` and `Job` handles are
 **never** folded — those are the ones a cross-process access question
-turns on — and neither is any row whose name could not be read. Every
-other anonymous type folds, and the fold line always names the type and
-its exact count, so nothing disappears unnamed.
+turns on — and neither is any row whose type or object name could not be
+**read**. Every other anonymous row folds, including one whose descriptor
+recorded no type name either (some dump writers record none for any
+handle); the fold line always names the type and its exact count, so
+nothing disappears unnamed.
 The two states are different facts and the console keeps them apart:
 
 - `(unnamed)` — the descriptor records no name. Nothing was lost.

--- a/docs/recon_process_sysinfo_handles_contract.md
+++ b/docs/recon_process_sysinfo_handles_contract.md
@@ -2825,16 +2825,30 @@ per-type counts, and `--verbose` renders every record.
   identical in both views. A folded row remains captured, normalized,
   counted, and present in `--json`. The headline and the `By type:` line
   always describe the **complete** inventory.
+- A row is **anonymous** when `object_name_status == "unnamed"` — the
+  descriptor positively records no object name. Only the **object** name
+  decides this; a row with a captured object name is never folded,
+  whatever its type says.
 - An anonymous row folds **unless** one of two things holds:
-  1. **the row lost evidence.** `object_name_status == "unreadable"` (a
-     name should have been there and the bounded read failed) is a
-     different fact from `"unnamed"` (the descriptor positively records
-     none), and so is an unreadable **type** name. Folding either would
-     hide the one row that says something was lost, so only a row whose
-     type read cleanly **and** whose object name is positively absent is
-     ever a fold candidate.
+  1. **the row lost evidence.** `"unreadable"` (a name should have been
+     there and the bounded read failed) is a different fact from
+     `"unnamed"` (the descriptor positively records none) — §5.2.1 — and
+     an `"unreadable"` status in **either** name field blocks folding.
+     That row is the one an analyst needs in order to know something was
+     lost.
+
+     This is a test for `type_name_status != "unreadable"`, **not** for
+     `== "ok"`, and the difference is normative. A descriptor whose
+     `TypeNameRva` is 0 has no type name at all, so its status is
+     `"unnamed"` — not a read failure, and not evidence loss. A row with
+     neither a type nor an object name is the **lowest**-context row the
+     table can hold, and real dump writers emit whole handle streams in
+     exactly that shape. Requiring a captured type name therefore
+     disables the fold precisely on the dumps that need it most, while
+     leaving every fixture that happens to carry type names passing.
   2. **its type is on the retain list**: `Job`, `Process`, `Section`,
-     `Thread`, `Token`.
+     `Thread`, `Token`. A `null` type name is not on it, so a typeless
+     anonymous row folds.
 - `object_name_status == "unnamed"` alone is therefore **not** the
   suppression rule: rule 2 is what keeps an anonymous `Process`,
   `Thread`, `Token`, `Section`, or `Job` handle — exactly the evidence a
@@ -2851,7 +2865,12 @@ per-type counts, and `--verbose` renders every record.
 - The fold line states the exact total, says **why** those rows folded
   (no object name recorded), lists the per-type counts ordered by §1.5
   (count descending, then type name ascending), and names `--verbose` as
-  the way to see them. Folding is deterministic, bounded,
+  the way to see them. Its type labels come from the same
+  `summarize_handles_by_type()`/`handle_name_display()` projection as
+  `By type:` and `summary.by_type`, so a folded row with no type name is
+  labelled `(unnamed)` there exactly as it is counted there, and a
+  captured type literally named `(unnamed)` still cannot merge into that
+  bucket. Folding is deterministic, bounded,
   and linear in the record count: it is decided per record with no
   cross-row state.
 - The two null-name labels are explained inline whenever one of them is
@@ -3448,7 +3467,12 @@ excuses anything in §0–§8.
      `Thread`, `Token`), not an allow-to-fold list: the first cut of this
      used the allow direction, which left every unlisted type visible and
      so still printed the wall of anonymous rows the fold exists to
-     collapse.
+     collapse. The second cut then gated folding on the type name having
+     been *captured* (`status == "ok"`), which pinned every row of a dump
+     whose writer left `TypeNameRva` 0 — the typeless, nameless rows that
+     are the least informative in the table — so the rule is now stated
+     as `!= "unreadable"`, i.e. only genuine evidence loss blocks a
+     fold.
   3. **The tables were separated but not aligned.** A per-column
      minimum width is not truncation, so one long type, DLL or API name
      pushed that one row's remaining columns right and left both tables

--- a/dumpex/commands/handles.py
+++ b/dumpex/commands/handles.py
@@ -469,9 +469,14 @@ _HANDLE_COLUMN_WIDTH = 18
 #      name should have been there and the bounded read failed) is a
 #      different fact from `"unnamed"` (the descriptor positively records
 #      none) -- §5.2.1 -- and so is an unreadable TYPE name. Folding
-#      either would hide the one row that says something was lost, so
-#      only a row whose type read cleanly AND whose object name is
-#      positively absent is ever a fold candidate.
+#      either would hide the one row that says something was lost.
+#
+#      Note what this does NOT require: that the type name READ. A
+#      descriptor with no type name at all (`TypeNameRva == 0`) is
+#      "unnamed", not a read failure, and a row with neither a type nor
+#      an object name is the lowest-context row the table can hold.
+#      Whole real handle streams are written that way, so demanding a
+#      captured type name here disables the fold on exactly those dumps.
 #   2. the type is on the retain list below.
 #
 # Condition 2 is why `object_name_status == "unnamed"` is not the sole
@@ -551,30 +556,49 @@ _NAME_STATUS_LEGEND = (
 def _is_foldable(record: HandleRecord) -> bool:
     """One record in, one bool out -- no cross-row state, so folding is
     deterministic and linear in the record count however the table is
-    ordered. Both name statuses are read as themselves (never as bare
-    truthiness of the name): "unnamed" and "unreadable" are different
-    facts (§5.2.1) and only the first is ever a fold candidate."""
-    return (record.object_name_status == "unnamed"
-            and record.type_name_status == "ok"
-            and record.type_name not in _RETAINED_ANONYMOUS_TYPES)
+    ordered.
+
+    Both name statuses are read as THEMSELVES, never as bare truthiness
+    of the name: "unnamed" and "unreadable" are different facts (§5.2.1),
+    and only the first is ever a fold candidate. The type is tested for
+    `!= "unreadable"` rather than `== "ok"`, and the difference is not
+    cosmetic -- requiring "ok" was the defect this predicate shipped
+    with. A descriptor whose `TypeNameRva` is 0 has NO type name and
+    therefore status "unnamed", which is not a read failure and not
+    evidence loss; it is the LOWEST-context row the table can hold (no
+    type, no object name, nothing left to investigate). Real dump writers
+    produce whole handle streams in exactly that shape, and requiring
+    "ok" pinned every one of those rows on screen -- i.e. it disabled the
+    fold precisely on the dumps that need it most, while the synthetic
+    fixtures (which all carry type names) kept passing.
+
+    An UNREADABLE name in either field still blocks folding, in both
+    directions: that is the one row an analyst needs in order to know
+    something was lost."""
+    if record.object_name_status != "unnamed":
+        return False
+    if record.type_name_status == "unreadable":
+        return False
+    # `type_name` is None for the no-type-name case above; `None` is not
+    # in the retain list, so such a row folds.
+    return record.type_name not in _RETAINED_ANONYMOUS_TYPES
 
 
-def _partition_for_console(records, verbose: bool) -> "tuple[list, dict]":
-    """-> (rows_to_print, {type_name: folded_count}).
+def _partition_for_console(records, verbose: bool) -> "tuple[list, list]":
+    """-> (rows_to_print, rows_folded). `verbose` folds nothing at all.
 
-    `verbose` folds nothing at all. The folded counts are ordered by
-    §1.5's frozen rule (count descending, then type name ascending) so
-    two runs over the same dump print the same line."""
+    Returns the folded RECORDS rather than a count per type name, so the
+    fold line can be built by summarize_handles_by_type() -- the same
+    projection `By type:` and `summary.by_type` use. Counting here
+    instead would key the line on the raw `type_name`, which merges a
+    null type into whatever a dump chose to call itself and loses §1.5's
+    ordering and handle_name_display()'s injective disambiguation."""
     if verbose:
-        return list(records), {}
-    shown = []
-    folded = {}
+        return list(records), []
+    shown, folded = [], []
     for record in records:
-        if _is_foldable(record):
-            folded[record.type_name] = folded.get(record.type_name, 0) + 1
-        else:
-            shown.append(record)
-    return shown, dict(sorted(folded.items(), key=lambda item: (-item[1], item[0])))
+        (folded if _is_foldable(record) else shown).append(record)
+    return shown, folded
 
 
 def _namespace_notes(records) -> list:
@@ -647,7 +671,6 @@ def render_handles_console(records, coverage, *, verbose: bool = False) -> None:
         print(f"  {YELLOW(text)}")
 
     shown, folded = _partition_for_console(records, verbose)
-    folded_total = sum(folded.values())
 
     if shown:
         # Cells are built once, up front, so the column widths below are
@@ -693,10 +716,15 @@ def render_handles_console(records, coverage, *, verbose: bool = False) -> None:
     # collected record -- it is in `by_type` above, in `summary.count`,
     # and in --json -- so this line says "not shown", never "not
     # captured".
-    if folded_total:
-        listed = ", ".join(f"{console_safe(name)} {count}" for name, count in folded.items())
+    if folded:
+        # summarize_handles_by_type(), so the fold line names a type
+        # exactly as `By type:` and `summary.by_type` do -- including a
+        # folded row that has no type name at all, which buckets as
+        # "(unnamed)" rather than under some other type.
+        listed = ", ".join(f"{console_safe(name)} {count}"
+                            for name, count in summarize_handles_by_type(folded).items())
         print()
-        print(f"  {folded_total} anonymous handle(s) not shown "
+        print(f"  {len(folded)} anonymous handle(s) not shown "
               f"(no object name recorded): {listed}")
         print(f"  {DIM(_FOLD_HINT)}")
 

--- a/tests/unit/test_handles_cmd.py
+++ b/tests/unit/test_handles_cmd.py
@@ -612,7 +612,11 @@ def test_missing_descriptor_count_never_invents_a_truncation():
 
 
 def test_console_marks_an_unavailable_access_mask_without_faking_a_value():
-    result = collect_handles(_mf_from_descriptors([_descriptor(0x10, granted_access=None)]))
+    # A retained type, so the row survives the default projection -- a
+    # descriptor with no type and no object name is the exact shape the
+    # fold collapses (#98), and this case is about the Access column.
+    result = collect_handles(_mf_from_descriptors(
+        [_descriptor(0x10, granted_access=None, type_name="Process", type_name_rva=8)]))
     row = next(l for l in _console(result).splitlines() if "0x0000000000000010" in l)
     # The Access column says the mask is unavailable -- never a
     # fabricated 0x00000000, which reads as a real, zero-rights mask.
@@ -727,9 +731,9 @@ def test_the_console_table_and_the_summary_project_names_the_same_way():
         {"handle": 0x20, "type_name": None, "object_name": None},
     ]))
     # Rendered verbose: both rows are anonymous, so the DEFAULT console
-    # folds one of them (#98). The claim under test is that the Type
-    # column and by_type project a name the same way, which is a property
-    # of the projection, not of which rows a view chose to print.
+    # folds BOTH (#98). The claim under test is that the Type column and
+    # by_type project a name the same way, which is a property of the
+    # projection, not of which rows a view chose to print.
     rows = [l for l in _console(result, verbose=True).splitlines() if "0x00000000000000" in l]
     types = [l.split("  ")[2].strip() for l in rows]
 
@@ -1198,6 +1202,77 @@ def test_an_unclassified_anonymous_type_is_folded_but_never_lost():
     assert "SomeFutureObjectType 1" in text                   # named and counted
     assert result.summary["by_type"] == {"SomeFutureObjectType": 1}
     assert len(_rows(_console(result, verbose=True))) == 1     # reachable
+
+
+def test_a_descriptor_with_no_type_name_at_all_is_folded():
+    """The shape that made the shipped fold a no-op on real dumps.
+
+    A dump writer that leaves `TypeNameRva` 0 produces descriptors with
+    NO type name -- status "unnamed", which is not a read failure -- and
+    typically no object name either. That is the lowest-context row the
+    table can hold, and whole handle streams are written that way. The
+    first cut of the predicate required `type_name_status == "ok"`, so
+    every one of those rows stayed pinned on screen and the fold did
+    nothing on exactly the dumps that need it; every fixture in this file
+    happened to carry a type name, so nothing caught it."""
+    result = collect_handles(_mf_with(
+        [{"handle": 0x10 + i, "type_name": None, "object_name": None} for i in range(8)]))
+    text = _console(result)
+
+    assert _rows(text) == []
+    assert "8 anonymous handle(s) not shown" in text
+    # Bucketed and labelled exactly as `By type:` labels it, so the two
+    # lines describe the same handles the same way.
+    assert "(unnamed) 8" in text
+    assert result.summary["by_type"] == {"(unnamed)": 8}
+    assert len(_rows(_console(result, verbose=True))) == 8
+
+
+def test_a_typeless_row_still_shows_when_it_has_an_object_name():
+    """Only the OBJECT name decides whether a row is anonymous. A
+    descriptor with no type name but a captured object name is evidence
+    an analyst reads, and it must survive the default projection."""
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": None, "object_name": r"\\Device\\HarddiskVolume1\\a.txt"},
+        {"handle": 0x20, "type_name": None, "object_name": None},
+    ]))
+    text = _console(result)
+    assert len(_rows(text)) == 1
+    assert "a.txt" in text
+    assert "1 anonymous handle(s) not shown" in text
+
+
+def test_an_unreadable_type_name_blocks_folding_even_when_anonymous():
+    """"unnamed" and "unreadable" stay different facts in the TYPE field
+    too: a type that should have been there and could not be read is
+    evidence loss, and the row that says so is never folded."""
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": BAD_RVA, "object_name": None},
+        {"handle": 0x20, "type_name": None, "object_name": None},
+    ]))
+    text = _console(result)
+    rows = _rows(text)
+
+    assert len(rows) == 1
+    assert "0x0000000000000010" in rows[0]        # the lost type name: kept
+    assert "(unreadable)" in rows[0]
+    assert "1 anonymous handle(s) not shown" in text
+
+
+def test_the_fold_line_and_by_type_never_describe_a_handle_differently():
+    """Both lines go through handle_name_display(), so a dump carrying a
+    type literally named "(unnamed)" cannot make the fold line claim a
+    handle is typeless -- nor merge into the null-type bucket."""
+    result = collect_handles(_mf_with([
+        {"handle": 0x10, "type_name": "(unnamed)", "object_name": None},
+        {"handle": 0x20, "type_name": None, "object_name": None},
+    ]))
+    fold_line = next(l for l in _console(result).splitlines() if "not shown" in l)
+
+    assert "(unnamed) 1" in fold_line
+    assert "(unnamed) [captured name] 1" in fold_line
+    for label in result.summary["by_type"]:
+        assert label in fold_line
 
 
 @pytest.mark.parametrize("type_name", ["Process", "Thread", "Token", "Section", "Job"])


### PR DESCRIPTION
Follow-up to #100. Reported from a real dump: `--handles` without `--verbose` still printed every `(unnamed)` row — the fold did nothing on exactly the output it exists to collapse.

## Root cause

`_is_foldable()` required `type_name_status == "ok"`.

A descriptor whose `TypeNameRva` is 0 has **no type name**, so its status is `"unnamed"` — not a read failure, and not evidence loss. A row with neither a type nor an object name is the **lowest**-context row the table can hold, and real dump writers emit whole handle streams in exactly that shape. Demanding a *captured* type name therefore disabled the fold precisely on the dumps that need it.

Every fixture in the suite happened to carry type names, which is why nothing caught it. One test comment had even recorded the symptom and rationalised it — "the default console folds **one** of them", written about two rows that are both anonymous.

```
0x0000000000000010  type=None/unnamed  object=None/unnamed  foldable=False   <-- the defect
0x0000000000000020  type='Event'/ok    object=None/unnamed  foldable=True
```

## The fix

The rule is now `type_name_status != "unreadable"`: only genuine evidence loss blocks a fold, in either name field.

- Whether a row is **anonymous** is decided by the **object** name alone, so a handle with a captured object name is still never folded whatever its type says.
- The `Job` / `Process` / `Section` / `Thread` / `Token` retain list is unchanged. A `null` type name is not on it, so a typeless anonymous row folds.
- An `"unreadable"` status in either field still pins the row — that is the one an analyst needs in order to know something was lost.

```text
  Handle              Type            Access      Cnt  Ptr  Object
  0x0000000000000100  (unnamed)       0x00000000    1    1  \Device\HarddiskVolume1\a.txt
  0x0000000000000110  (unnamed)       0x00000000    1    1  (unreadable)
  0x0000000000000120  (unreadable)    0x00000000    1    1  (unnamed)
  0x0000000000000130  Process         0x00000000    1    1  (unnamed)

  9 anonymous handle(s) not shown (no object name recorded): (unnamed) 8, Event 1
```

`_partition_for_console()` now returns the folded **records** instead of a count keyed on the raw `type_name`, and the fold line is built with `summarize_handles_by_type()` — the same projection `By type:` and `summary.by_type` use. A folded row with no type name is therefore labelled `(unnamed)` in the fold line exactly as it is counted in `by_type`, and a dump carrying a type literally named `(unnamed)` still cannot merge into that bucket.

Still console-only: records, summary, `by_type`, coverage, limitations and exit code are untouched, and `--verbose` prints every record.

## Tests

`5257 passed, 1 skipped`. The new regression tests are driven by the **real-dump shape** rather than by type-name-carrying fixtures:

- a stream of typeless anonymous descriptors folds and is reported as `(unnamed) N`, with all rows reachable under `--verbose`;
- a typeless row with a captured object name stays on screen;
- an unreadable type name blocks the fold while a merely absent one does not;
- the fold line and `by_type` are asserted to label the same handles the same way.

Contract §5.6.1, the CLI reference and the CHANGELOG restate the rule, and Appendix A's rev6 entry records this second miss alongside the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
