### PR TITLE
ci: tier test runs by event and sync main outward automatically

### DIFF
--- a/.github/workflows/repository-leak-scan.yml
+++ b/.github/workflows/repository-leak-scan.yml
@@ -17,6 +17,15 @@ permissions:
 
 jobs:
   leak-scan:
+    # Gitleaks below scans `--log-opts=--all`, i.e. every commit reachable in
+    # the repository -- not the diff. For a branch in this repository the
+    # push event has therefore already scanned exactly what the matching
+    # pull_request event would scan, so running both was pure duplication.
+    # Fork pull requests are the one case where that is not true: their
+    # commits never produce a push event here, so they still get scanned.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/sync-main-to-all-branches.yml
+++ b/.github/workflows/sync-main-to-all-branches.yml
@@ -1,11 +1,26 @@
 name: Sync main to all branches
 
+# Long-lived branches (architecture_restructure, feature_adding,
+# urgent_patch, ...) drift the moment a pull request lands on main. The
+# cost of that drift is not paid here -- it is paid weeks later, as a
+# conflict in whichever branch merged second. So main is merged outward
+# automatically the moment it moves, not whenever someone remembers to
+# press a button.
+#
+# Note on CI: pushes made with GITHUB_TOKEN deliberately do not trigger
+# other workflows. Syncing therefore costs zero test runs -- but it also
+# means an open pull request's green checks still describe the tree from
+# BEFORE the sync. Push any commit (or re-run its checks) to re-validate.
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
   contents: write
 
+# Never let two syncs interleave; queue the second one instead of
+# cancelling it, so no push to main is silently dropped.
 concurrency:
   group: sync-main-to-all-branches
   cancel-in-progress: false
@@ -14,6 +29,7 @@ jobs:
   sync:
     name: Merge main into every branch
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Check out main with full history
@@ -22,12 +38,15 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Preflight every merge, then push atomically
+      - name: Merge main into every other branch, independently
         shell: bash
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          set -euo pipefail
+          # No `set -e`: a branch that will not merge is an expected
+          # outcome to be reported, not a reason to abandon the branches
+          # that would have merged fine.
+          set -uo pipefail
 
           if [[ "$DEFAULT_BRANCH" != "main" ]]; then
             echo "This workflow expects the repository default branch to be 'main', but it is '$DEFAULT_BRANCH'." >&2
@@ -46,43 +65,103 @@ jobs:
 
           if (( ${#branches[@]} == 0 )); then
             echo "No branches other than main were found."
-            echo "## Sync result" >> "$GITHUB_STEP_SUMMARY"
-            echo "No branches other than \`main\` were found." >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "## Sync result"
+              echo
+              echo "No branches other than \`main\` were found."
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          updates=()
           synced=()
+          already=()
+          conflicted=()
+          rejected=()
 
-          # Build every merge locally first. Nothing is pushed unless all
-          # branches merge cleanly, so a conflict cannot leave a partial sync.
-          for index in "${!branches[@]}"; do
-            branch="${branches[$index]}"
-            local_ref="refs/heads/sync-main-$index"
+          # Each branch is merged and pushed on its own. The previous
+          # revision preflighted every merge and pushed atomically, which
+          # sounds safer but inverts the priority: one stale or abandoned
+          # branch then blocked the sync for every healthy branch, every
+          # time, until a human intervened. Independent pushes mean a
+          # conflict costs exactly the branch it is on.
+          for branch in "${branches[@]}"; do
+            echo "::group::main -> $branch"
 
-            echo "Preflighting main -> $branch"
-            git switch --detach "refs/remotes/origin/$branch"
-
-            if ! git merge --no-edit refs/remotes/origin/main; then
-              git merge --abort || true
-              echo "main could not be merged cleanly into '$branch'. Nothing was pushed." >&2
-              exit 1
+            if git merge-base --is-ancestor refs/remotes/origin/main "refs/remotes/origin/$branch"; then
+              echo "Already contains main; nothing to do."
+              already+=("$branch")
+              echo "::endgroup::"
+              continue
             fi
 
-            git update-ref "$local_ref" HEAD
-            updates+=("$local_ref:refs/heads/$branch")
-            synced+=("$branch")
-          done
+            pushed=false
+            # Attempt twice: between fetch and push the branch may have
+            # received a commit, which the remote rejects as non-fast-
+            # forward. Re-fetching and rebuilding the merge on the new tip
+            # resolves the ordinary version of that race.
+            for attempt in 1 2; do
+              git switch --detach "refs/remotes/origin/$branch" --quiet
 
-          # GitHub supports atomic pushes: if any branch rejects its update
-          # (for example due to protection or a concurrent push), none change.
-          git push --atomic origin "${updates[@]}"
+              if ! git merge --no-edit -m "Merge main into $branch" refs/remotes/origin/main; then
+                conflicts="$(git diff --name-only --diff-filter=U | paste -sd', ' -)"
+                git merge --abort || true
+                echo "Conflict in: ${conflicts:-<unknown>}" >&2
+                conflicted+=("$branch|${conflicts:-unknown}")
+                break
+              fi
+
+              if git push origin "HEAD:refs/heads/$branch"; then
+                pushed=true
+                break
+              fi
+
+              echo "Push to '$branch' was rejected (attempt $attempt); re-fetching." >&2
+              git fetch origin "+refs/heads/$branch:refs/remotes/origin/$branch"
+            done
+
+            if [[ "$pushed" == true ]]; then
+              synced+=("$branch")
+            elif [[ "${conflicted[*]-}" != *"$branch|"* ]]; then
+              rejected+=("$branch")
+            fi
+
+            echo "::endgroup::"
+          done
 
           {
             echo "## Sync result"
             echo
-            echo "Merged \`main\` into ${#synced[@]} branch(es):"
-            for branch in "${synced[@]}"; do
-              echo "- \`$branch\`"
+            echo "| Branch | Result |"
+            echo "| --- | --- |"
+            for branch in "${synced[@]-}";  do [[ -n "$branch" ]] && echo "| \`$branch\` | ✅ merged and pushed |"; done
+            for branch in "${already[@]-}"; do [[ -n "$branch" ]] && echo "| \`$branch\` | ➖ already up to date |"; done
+            for entry in "${conflicted[@]-}"; do
+              [[ -n "$entry" ]] || continue
+              echo "| \`${entry%%|*}\` | ❌ conflict in ${entry#*|} — **not pushed** |"
             done
+            for branch in "${rejected[@]-}"; do [[ -n "$branch" ]] && echo "| \`$branch\` | ⚠️ push rejected (branch moved or protected) — **not pushed** |"; done
           } >> "$GITHUB_STEP_SUMMARY"
+
+          failures=$(( ${#conflicted[@]} + ${#rejected[@]} ))
+          if (( failures > 0 )); then
+            {
+              echo
+              echo "### Resolve manually"
+              echo
+              echo '```bash'
+              for entry in "${conflicted[@]-}"; do
+                [[ -n "$entry" ]] || continue
+                branch="${entry%%|*}"
+                echo "git switch $branch && git pull && git merge main   # then resolve, commit, push"
+              done
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            # Fail the job so the run goes red and GitHub sends its usual
+            # failed-workflow notification. Every branch that COULD sync
+            # already has -- this is a report, not a rollback.
+            echo "$failures branch(es) could not be synced; see the job summary." >&2
+            exit 1
+          fi
+
+          echo "All branches are in sync with main."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,108 @@
 name: Tests
 
+# One PR used to cost three identical full runs: the branch push, the
+# pull_request event fired seconds later on the same tree, and the push to
+# main after the merge. The `plan` job below collapses that -- see its own
+# comment for the tiering rules.
 on:
   push:
     branches: ["**"]
   pull_request:
+  workflow_dispatch:
+
+# A second push supersedes the first: nothing is learned from finishing a
+# run against a tree that is already stale. main is exempt -- every commit
+# that lands there gets its own complete, uncancelled verification.
+concurrency:
+  group: tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  plan:
+    # Decides how much of this workflow actually needs to run, so the same
+    # tree is never fully tested twice:
+    #
+    #   skip  push to a branch that already has an open PR. The
+    #         pull_request event fires on the same commit (they landed 33s
+    #         apart before this job existed) and tests refs/pull/N/merge,
+    #         which is strictly more relevant. The push run added nothing.
+    #   fast  push to a branch with no open PR -- pre-PR work in progress.
+    #         One leg (ubuntu + 3.12), no coverage, no auxiliary jobs:
+    #         ~1 minute for "did I break something obvious".
+    #   full  every pull_request, every push to main, every manual
+    #         dispatch. The complete 2x2 matrix plus the packaging,
+    #         minidump-pin and pin-consistency jobs.
+    #
+    # This job is deliberately checkout-free; it is metadata only.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      mode: ${{ steps.pick.outputs.mode }}
+      os: ${{ steps.pick.outputs.os }}
+      python: ${{ steps.pick.outputs.python }}
+    steps:
+      - name: Pick test tier for this event
+        id: pick
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          # Never interpolate a ref straight into a shell script: a branch
+          # name is attacker-controllable on a public repo and would be
+          # evaluated by bash. Pass it as an environment value instead.
+          REF_NAME: ${{ github.ref_name }}
+          REF: ${{ github.ref }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+
+          mode=full
+          if [[ "$EVENT_NAME" == "push" && "$REF" != "refs/heads/main" ]]; then
+            # `gh api` fails open here: if the lookup errors we assume no
+            # PR and run the fast lane, which is the safe direction (extra
+            # signal, never missing signal).
+            open_prs="$(gh api \
+              --method GET \
+              "repos/$REPO/pulls" \
+              -f state=open \
+              -f "head=$OWNER:$REF_NAME" \
+              --jq 'length' 2>/dev/null || echo 0)"
+
+            if [[ "$open_prs" -gt 0 ]]; then
+              mode=skip
+            else
+              mode=fast
+            fi
+          fi
+
+          case "$mode" in
+            full) os='["ubuntu-latest", "windows-latest"]'; python='["3.10", "3.12"]' ;;
+            *)    os='["ubuntu-latest"]';                   python='["3.12"]' ;;
+          esac
+
+          {
+            echo "mode=$mode"
+            echo "os=$os"
+            echo "python=$python"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Test tier: \`$mode\`"
+            echo
+            case "$mode" in
+              skip) echo "Branch \`$REF_NAME\` has an open pull request; its \`pull_request\` run tests the same commit merged into \`main\`. Nothing to do here." ;;
+              fast) echo "Pre-PR push: ubuntu-latest / Python 3.12 only, no coverage gates. Open a pull request for the full matrix." ;;
+              full) echo "Full matrix: ubuntu-latest + windows-latest, Python 3.10 + 3.12, coverage gates, packaging and minidump-pin jobs." ;;
+            esac
+          } >> "$GITHUB_STEP_SUMMARY"
+
   pytest:
+    needs: plan
+    if: needs.plan.outputs.mode != 'skip'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -15,7 +111,7 @@ jobs:
         # version stands in for "a main supported runtime". No real
         # .dmp/PE sample files are needed — the suite builds its own
         # synthetic fixtures (see tests/fixtures/fakes.py).
-        python-version: ["3.10", "3.12"]
+        python-version: ${{ fromJSON(needs.plan.outputs.python) }}
         # dumpex parses Windows minidumps and reasons about Windows-
         # specific memory/protection semantics (MEM_IMAGE/MEM_PRIVATE,
         # PAGE_EXECUTE_WRITECOPY, backslash paths in module/PEB records,
@@ -23,7 +119,7 @@ jobs:
         # platform it targets. Path handling, file-locking/O_EXCL
         # semantics (safe_io), and temp-directory behavior can all differ
         # in ways Linux CI can't catch.
-        os: [ubuntu-latest, windows-latest]
+        os: ${{ fromJSON(needs.plan.outputs.os) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +127,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          # Cache the pip *download* cache, keyed on pyproject.toml. The
+          # install itself still runs (an editable install must), but the
+          # wheels no longer come off the network on every leg -- which is
+          # where a large share of the Windows legs' wall time went.
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install dumpex with dev + optional extras
         run: pip install -e ".[dev,full]"
@@ -63,8 +165,24 @@ jobs:
         # (delete its entry); the known ones warn.
         run: pytest tests/unit/test_console_untrusted_text.py -v -W "always::UserWarning"
 
-      - name: Run pytest with coverage (overall gate — see pyproject.toml [tool.coverage.report])
-        run: pytest --cov=dumpex --cov-report=term-missing
+      - name: Run pytest (coverage measured on the ubuntu / 3.12 leg only)
+        # The coverage gates below are platform- and version-independent by
+        # construction -- the same thresholds were already applied to all
+        # four legs, because "the modules under test don't branch on
+        # platform". Measuring the identical numbers four times bought
+        # nothing, so exactly one leg carries --cov and the other legs run
+        # the suite plain. Coverage still gates every pull request and
+        # every commit on main; it is skipped on the pre-PR fast lane.
+        shell: bash
+        env:
+          COVERAGE_LEG: ${{ needs.plan.outputs.mode == 'full' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
+        run: |
+          set -euo pipefail
+          if [[ "$COVERAGE_LEG" == "true" ]]; then
+            pytest --cov=dumpex --cov-report=term-missing
+          else
+            pytest
+          fi
 
       - name: Coverage gate — key detection modules
         # Use the same fail-fast native-command semantics on every runner.
@@ -78,8 +196,12 @@ jobs:
         # this was added — raise them as coverage improves, don't lower
         # them to make a failing PR pass. Same thresholds on every OS in
         # the matrix: the modules under test don't branch on platform, so
-        # coverage shouldn't either.
-        if: always()
+        # coverage shouldn't either -- which is exactly why only the
+        # ubuntu/3.12 leg measures it. `always()` keeps this step running
+        # when the suite above failed, so both classes of regression
+        # surface in one run; the leg check keeps it off the legs that
+        # produced no .coverage file to report on.
+        if: always() && needs.plan.outputs.mode == 'full' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         run: |
           coverage report --include="dumpex/core/pe_utils.py"   --fail-under=56
           coverage report --include="dumpex/hunt/_coverage.py"  --fail-under=85
@@ -370,6 +492,12 @@ jobs:
     # pyproject.toml, also add the actual highest minidump release that
     # now falls in range (check PyPI -- don't invent a version number
     # that may not exist).
+    needs: plan
+    # Auxiliary gate: full tier only (pull requests, main, manual
+    # dispatch). The pre-PR fast lane deliberately skips it -- packaging
+    # metadata and the minidump pin change on the order of once a
+    # release, not once a work-in-progress commit.
+    if: needs.plan.outputs.mode == 'full'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -414,6 +542,12 @@ jobs:
     # matrix above vs. pyproject.toml's specifier) shows up as its own
     # named, easy-to-spot job rather than one assertion buried in a much
     # larger test run.
+    needs: plan
+    # Auxiliary gate: full tier only (pull requests, main, manual
+    # dispatch). The pre-PR fast lane deliberately skips it -- packaging
+    # metadata and the minidump pin change on the order of once a
+    # release, not once a work-in-progress commit.
+    if: needs.plan.outputs.mode == 'full'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -440,6 +574,12 @@ jobs:
     # packaged rules.yaml / YARA rules / JSON schema are actually inside
     # the distributed artifact and readable via importlib.resources --
     # not just present in the source tree.
+    needs: plan
+    # Auxiliary gate: full tier only (pull requests, main, manual
+    # dispatch). The pre-PR fast lane deliberately skips it -- packaging
+    # metadata and the minidump pin change on the order of once a
+    # release, not once a work-in-progress commit.
+    if: needs.plan.outputs.mode == 'full'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
One pull request cost three identical full test runs. Measured on #98: the branch push at 03:26:07, the pull_request event 33 seconds later on the same commit, and the push to main after the merge at 03:34:13 -- roughly 32 runner-minutes each, eight jobs each, testing the same tree. Nothing was learned the second or third time.

Tests now decides its own scope. A new checkout-free `plan` job resolves the event to one of three tiers:

  skip  a push to a branch that already has an open pull request. That
        pull_request event fires on the same commit and tests
        refs/pull/N/merge, which is strictly more relevant than the raw
        branch tip. The push run was pure duplication.
  fast  a push to a branch with no open pull request -- pre-PR work in
        progress. One leg (ubuntu-latest, Python 3.12), no coverage, no
        auxiliary jobs.
  full  every pull_request, every push to main, every manual dispatch.
        The complete 2x2 matrix plus package-smoke, minidump-version-
        range and minidump-version-pin-consistency.

The open-PR lookup fails open: a `gh api` error yields the fast lane rather than nothing, so a broken lookup can only cost extra signal, never lose it. Every ref reaches the script through the environment, never by interpolation -- a branch name is attacker-controllable on a public repo and `${{ }}` inside `run:` is evaluated by bash.

Three narrower reductions in the same workflow:

`concurrency` did not exist, so pushing twice ran both sets of eight jobs to completion against a tree that was already stale. Runs are now superseded per pull request / per ref, with main exempt: every commit that lands there keeps its own complete, uncancelled verification.

Coverage is measured on the ubuntu/3.12 leg alone. The per-module gates were already applied identically to all four legs -- this workflow's own comment records why ("the modules under test don't branch on platform, so coverage shouldn't either"). Measuring the same numbers four times produced no information. The other legs run the suite plain; the gates still guard every pull request and every commit on main.

setup-python now keeps pip's download cache, keyed on pyproject.toml. The editable install still runs, but the wheels stop coming off the network on every leg, which was a large share of the Windows legs' 4m40s.

Repository Leak Scan skips same-repository pull requests. Gitleaks scans --log-opts=--all, every reachable commit rather than the diff, so the push event had already scanned exactly what the matching pull_request event would scan. Fork pull requests are the one case where that is not true -- their commits never produce a push event here -- and they are still scanned.

Sync main to all branches was manual, which defeated its own purpose: the failure it exists to prevent is forgetting to sync, and it depended on remembering to press a button. It now runs on every push to main.

It also gives up atomicity, deliberately. Preflighting every merge and pushing with --atomic sounds safer, but it inverts the priority: a single stale or abandoned branch blocked the sync for every healthy branch, every time, until a human intervened. Each branch is now merged and pushed independently, so a conflict costs exactly the branch it is on. The job still fails at the end when any branch could not be synced, so the run goes red and GitHub sends its usual notification -- that is a report, not a rollback, and every branch that could sync already has.

Branches already containing main are skipped rather than given an empty merge commit, a rejected push is retried once against a re-fetched tip (the branch may move between fetch and push), and the summary table names each conflicting file plus the command to resolve it by hand.

Note for readers of a synced pull request: pushes made with GITHUB_TOKEN do not trigger workflows, so syncing costs no test runs -- but a green check on an open pull request still describes the tree from before the sync.